### PR TITLE
appengine: Add support for sending data to APIs

### DIFF
--- a/interfaces/utils.go
+++ b/interfaces/utils.go
@@ -15,16 +15,22 @@
 package interfaces
 
 import (
+	"errors"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 )
 
-// ValidateAggregateMessage validates an aggregate message
-func ValidateAggregateMessage(astarteInterface AstarteInterface, values map[string]interface{}) error {
+// ValidateAggregateMessage validates an aggregate message prepended by a path.
+// values must be a map containing the last tip of the endpoint, without slashes
+func ValidateAggregateMessage(astarteInterface AstarteInterface, interfacePath string, values map[string]interface{}) error {
 	for k, v := range values {
-		// Validate the individual message
-		if err := ValidateIndividualMessage(astarteInterface, k, v); err != nil {
+		if strings.Contains(k, "/") {
+			return errors.New("values must contain keys without slash")
+		}
+		// Create a valid path to be fed to ValidateIndividualMessage
+		if err := ValidateIndividualMessage(astarteInterface, path.Join(interfacePath, k), v); err != nil {
 			return err
 		}
 	}

--- a/interfaces/utils.go
+++ b/interfaces/utils.go
@@ -15,9 +15,11 @@
 package interfaces
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"path"
+	"reflect"
 	"strings"
 	"time"
 )
@@ -150,6 +152,62 @@ func InterfaceMappingFromPath(astarteInterface AstarteInterface, interfacePath s
 func ValidateInterfacePath(astarteInterface AstarteInterface, interfacePath string) error {
 	_, err := InterfaceMappingFromPath(astarteInterface, interfacePath)
 	return err
+}
+
+// NormalizePayload returns a normalized payload, ready to be used for calling APIs or, in general, interact with
+// Astarte. encodeBytes controls whether []byte types should be encoded in base64, used for data structures which do not
+// support bytes (e.g.: JSON)
+func NormalizePayload(payload interface{}, encodeBytes bool) interface{} {
+	// Normalize payload as much as possible. In particular, we want to send base64 data in case we're dealing with a bytearray,
+	// and ensure time is always UTC
+	switch v := payload.(type) {
+	case []byte:
+		if encodeBytes {
+			payload = base64.StdEncoding.EncodeToString(v)
+		}
+	case [][]byte:
+		if encodeBytes {
+			newSlice := []string{}
+			for _, entry := range v {
+				newSlice = append(newSlice, base64.StdEncoding.EncodeToString(entry))
+			}
+			payload = newSlice
+		}
+	case time.Time:
+		payload = v.UTC()
+	case *time.Time:
+		payload = v.UTC()
+	default:
+		// Otherwise, use reflection to understand whether we're dealing with a Map or
+		// a Slice. If so, recurse and normalize all of it.
+		switch v := reflect.ValueOf(payload); v.Kind() {
+		case reflect.Map:
+			// Create a reflect Map for map[string]interface{}. This because type conversions might happen
+			// e.g.: []byte -> string
+			targetType := map[string]interface{}{}
+			copy := reflect.New(reflect.TypeOf(targetType)).Elem()
+			copy.Set(reflect.MakeMap(reflect.TypeOf(targetType)))
+			for _, key := range v.MapKeys() {
+				originalValue := v.MapIndex(key)
+				// Normalize inner value
+				normalizedValue := reflect.ValueOf(NormalizePayload(originalValue.Interface(), encodeBytes))
+				copy.SetMapIndex(key, normalizedValue)
+			}
+			payload = copy.Interface()
+		case reflect.Slice:
+			// Create a reflect Slice for []interface{}. This because type conversions might happen
+			// e.g.: []byte -> string
+			targetType := []interface{}{}
+			copy := reflect.New(reflect.TypeOf(targetType)).Elem()
+			copy.Set(reflect.MakeSlice(reflect.TypeOf(targetType), v.Len(), v.Cap()))
+			for i := 0; i < v.Len(); i++ {
+				copy.Index(i).Set(reflect.ValueOf(NormalizePayload(v.Index(i).Interface(), encodeBytes)))
+			}
+			payload = copy.Interface()
+		}
+	}
+
+	return payload
 }
 
 func simpleMappingValidation(astarteInterface AstarteInterface, interfacePath string) (AstarteInterfaceMapping, error) {

--- a/interfaces/utils_test.go
+++ b/interfaces/utils_test.go
@@ -172,7 +172,7 @@ func TestAggregateMessageValidation(t *testing.T) {
 	if err := ValidateInterfacePath(i, "/sensors/testSensor/name"); err != nil {
 		t.Error(err)
 	}
-	if err := ValidateAggregateMessage(i, map[string]interface{}{"/sensors/testSensor/name": "test"}); err != nil {
+	if err := ValidateAggregateMessage(i, "/sensors/testSensor", map[string]interface{}{"name": "test"}); err != nil {
 		t.Error(err)
 	}
 
@@ -230,7 +230,7 @@ func TestAggregateMessageWrongPaths(t *testing.T) {
 	if err := ValidateInterfacePath(i, "/sensors/testSensor/names"); err == nil {
 		t.Fail()
 	}
-	if err := ValidateAggregateMessage(i, map[string]interface{}{"/sensors/testSensor/names": "check"}); err == nil {
+	if err := ValidateAggregateMessage(i, "/sensors/testSensor", map[string]interface{}{"names": "check"}); err == nil {
 		t.Fail()
 	}
 	if _, err := InterfaceMappingFromPath(i, "/sensors/testSensor/names"); err == nil {

--- a/interfaces/utils_test.go
+++ b/interfaces/utils_test.go
@@ -15,7 +15,10 @@
 package interfaces
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -492,5 +495,81 @@ func TestFailedTypeValidation(t *testing.T) {
 	}
 	if err := ValidateIndividualMessage(i, "/stringValue", 42); err == nil {
 		t.Fail()
+	}
+}
+
+func TestPayloadNormalization(t *testing.T) {
+	byteArray := []byte{'a', 's', 't', 'a', 'r', 't', 'e'}
+	if NormalizePayload(byteArray, true).(string) != base64.StdEncoding.EncodeToString(byteArray) {
+		t.Error("Base64 matching in normalization failed")
+	}
+	if !bytes.Equal(NormalizePayload(byteArray, false).([]byte), byteArray) {
+		t.Error("Base64 matching in normalization failed")
+	}
+
+	timestamp := time.Now()
+	loc, err := time.LoadLocation("Europe/Rome")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if NormalizePayload(timestamp.In(loc), true) != timestamp.UTC() {
+		t.Error("Time conversion failed", timestamp.In(loc), timestamp.UTC())
+	}
+
+	inMap := map[string]time.Time{"testTime": timestamp.In(loc)}
+	outMap := map[string]interface{}{"testTime": timestamp.UTC()}
+
+	if !reflect.DeepEqual(NormalizePayload(inMap, true), outMap) {
+		t.Error("Map conversion failed", NormalizePayload(inMap, true), outMap)
+	}
+
+	inInterfaceMap := map[string]interface{}{"testTime": timestamp.In(loc)}
+
+	if !reflect.DeepEqual(NormalizePayload(inInterfaceMap, true), outMap) {
+		t.Error("Map conversion failed", NormalizePayload(inInterfaceMap, true), outMap)
+	}
+
+	inSlice := [][]byte{byteArray}
+	outSlice := []string{base64.StdEncoding.EncodeToString(byteArray)}
+
+	if !reflect.DeepEqual(NormalizePayload(inSlice, true), outSlice) {
+		t.Error("Slice conversion failed", NormalizePayload(inSlice, true), outSlice)
+	}
+
+	inInterfaceSlice := []interface{}{byteArray}
+	outInterfaceSlice := []interface{}{base64.StdEncoding.EncodeToString(byteArray)}
+
+	if !reflect.DeepEqual(NormalizePayload(inInterfaceSlice, true), outInterfaceSlice) {
+		t.Error("Slice conversion failed", NormalizePayload(inInterfaceSlice, true), outInterfaceSlice)
+	}
+
+	inMultiMap := map[string]interface{}{
+		"testTime":            timestamp.In(loc),
+		"testBytearray":       byteArray,
+		"testNestedBytearray": [][]byte{byteArray},
+		"testString":          "test",
+		"testStringArray":     []string{"test"},
+	}
+	outMultiMapEncoded := map[string]interface{}{
+		"testTime":            timestamp.UTC(),
+		"testBytearray":       base64.StdEncoding.EncodeToString(byteArray),
+		"testNestedBytearray": []string{base64.StdEncoding.EncodeToString(byteArray)},
+		"testString":          "test",
+		"testStringArray":     []interface{}{"test"},
+	}
+	outMultiMapNonEncoded := map[string]interface{}{
+		"testTime":            timestamp.UTC(),
+		"testBytearray":       byteArray,
+		"testNestedBytearray": [][]byte{byteArray},
+		"testString":          "test",
+		"testStringArray":     []interface{}{"test"},
+	}
+
+	if !reflect.DeepEqual(NormalizePayload(inMultiMap, true), outMultiMapEncoded) {
+		t.Error("Multimap conversion failed", NormalizePayload(inMultiMap, true), outMultiMapEncoded)
+	}
+	if !reflect.DeepEqual(NormalizePayload(inMultiMap, false), outMultiMapNonEncoded) {
+		t.Error("Multimap conversion failed", NormalizePayload(inMultiMap, false), outMultiMapNonEncoded)
 	}
 }


### PR DESCRIPTION
This also changes the validation semantics for Aggregates, ensuring we can keep a consistent approach everywhere from 1.0 onwards.