### PR TITLE
interfaces: Use string enums

### DIFF
--- a/interfaces/astarte_interface.go
+++ b/interfaces/astarte_interface.go
@@ -16,372 +16,298 @@ package interfaces
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
 
 // AstarteInterfaceType represents which kind of Astarte interface the object represents
-type AstarteInterfaceType int
+type AstarteInterfaceType string
 
 const (
 	// PropertiesType represents a properties Interface
-	PropertiesType AstarteInterfaceType = iota
+	PropertiesType AstarteInterfaceType = "properties"
 	// DatastreamType represents a datastream Interface
-	DatastreamType
+	DatastreamType AstarteInterfaceType = "datastream"
 )
 
-func (s AstarteInterfaceType) String() string {
-	return astarteInterfaceTypeToString[s]
-}
-
-var astarteInterfaceTypeToString = map[AstarteInterfaceType]string{
-	PropertiesType: "properties",
-	DatastreamType: "datastream",
-}
-
-var astarteInterfaceTypeToID = map[string]AstarteInterfaceType{
-	"properties": PropertiesType,
-	"datastream": DatastreamType,
-}
-
-// MarshalJSON marshals the enum as a quoted json string
-func (s AstarteInterfaceType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(astarteInterfaceTypeToString[s])
+// IsValid returns an error if AstarteInterfaceType does not represent a valid Astarte Interface Type
+func (t AstarteInterfaceType) IsValid() error {
+	switch t {
+	case PropertiesType, DatastreamType:
+		return nil
+	}
+	return errors.New("invalid Astarte Interface type")
 }
 
 // UnmarshalJSON unmashals a quoted json string to the enum value
-func (s *AstarteInterfaceType) UnmarshalJSON(b []byte) error {
+func (t *AstarteInterfaceType) UnmarshalJSON(b []byte) error {
 	var j string
-	err := json.Unmarshal(b, &j)
-	if err != nil {
+	if err := json.Unmarshal(b, &j); err != nil {
 		return err
 	}
-	// If the string cannot be found, an error is thrown.
-	if val, ok := astarteInterfaceTypeToID[j]; ok {
-		*s = val
-	} else {
+
+	*t = AstarteInterfaceType(j)
+	if err := t.IsValid(); err != nil {
 		return fmt.Errorf("'%v' is not a valid Astarte Interface Type", j)
 	}
 	return nil
 }
 
 // AstarteInterfaceOwnership represents the owner of an interface.
-type AstarteInterfaceOwnership int
+type AstarteInterfaceOwnership string
 
 const (
 	// DeviceOwnership represents a Device-owned interface
-	DeviceOwnership AstarteInterfaceOwnership = iota
+	DeviceOwnership AstarteInterfaceOwnership = "device"
 	// ServerOwnership represents a Server-owned interface
-	ServerOwnership
+	ServerOwnership AstarteInterfaceOwnership = "server"
 )
 
-func (s AstarteInterfaceOwnership) String() string {
-	return astarteInterfaceOwnershipToString[s]
-}
-
-var astarteInterfaceOwnershipToString = map[AstarteInterfaceOwnership]string{
-	DeviceOwnership: "device",
-	ServerOwnership: "server",
-}
-
-var astarteInterfaceOwnershipToID = map[string]AstarteInterfaceOwnership{
-	"device": DeviceOwnership,
-	"server": ServerOwnership,
-}
-
-// MarshalJSON marshals the enum as a quoted json string
-func (s AstarteInterfaceOwnership) MarshalJSON() ([]byte, error) {
-	return json.Marshal(astarteInterfaceOwnershipToString[s])
+// IsValid returns an error if AstarteInterfaceOwnership does not represent a valid Astarte Ownership Type
+func (o AstarteInterfaceOwnership) IsValid() error {
+	switch o {
+	case DeviceOwnership, ServerOwnership:
+		return nil
+	}
+	return errors.New("invalid Astarte Interface ownership")
 }
 
 // UnmarshalJSON unmashals a quoted json string to the enum value
-func (s *AstarteInterfaceOwnership) UnmarshalJSON(b []byte) error {
+func (o *AstarteInterfaceOwnership) UnmarshalJSON(b []byte) error {
 	var j string
-	err := json.Unmarshal(b, &j)
-	if err != nil {
+	if err := json.Unmarshal(b, &j); err != nil {
 		return err
 	}
-	// If the string cannot be found, an error is thrown.
-	if val, ok := astarteInterfaceOwnershipToID[j]; ok {
-		*s = val
-	} else {
+
+	*o = AstarteInterfaceOwnership(j)
+	if err := o.IsValid(); err != nil {
 		return fmt.Errorf("'%v' is not a valid Astarte Interface Ownership", j)
 	}
 	return nil
 }
 
 // AstarteInterfaceAggregation represents the type of Aggregation of an Interface.
-type AstarteInterfaceAggregation int
+type AstarteInterfaceAggregation string
 
 const (
 	// IndividualAggregation represents an interface with individual endpoints
-	IndividualAggregation AstarteInterfaceAggregation = iota
+	IndividualAggregation AstarteInterfaceAggregation = "individual"
 	// ObjectAggregation represents an interface with aggregated endpoints
-	ObjectAggregation
+	ObjectAggregation AstarteInterfaceAggregation = "object"
 )
 
-func (s AstarteInterfaceAggregation) String() string {
-	return astarteInterfaceAggregationToString[s]
-}
-
-var astarteInterfaceAggregationToString = map[AstarteInterfaceAggregation]string{
-	IndividualAggregation: "individual",
-	ObjectAggregation:     "object",
-}
-
-var astarteInterfaceAggregationToID = map[string]AstarteInterfaceAggregation{
-	"individual": IndividualAggregation,
-	"object":     ObjectAggregation,
-}
-
-// MarshalJSON marshals the enum as a quoted json string
-func (s AstarteInterfaceAggregation) MarshalJSON() ([]byte, error) {
-	return json.Marshal(astarteInterfaceAggregationToString[s])
+// IsValid returns an error if AstarteInterfaceAggregation does not represent a valid Astarte Interface Aggregation
+func (a AstarteInterfaceAggregation) IsValid() error {
+	switch a {
+	case IndividualAggregation, ObjectAggregation:
+		return nil
+	}
+	return errors.New("invalid Astarte Interface aggregation")
 }
 
 // UnmarshalJSON unmashals a quoted json string to the enum value
-func (s *AstarteInterfaceAggregation) UnmarshalJSON(b []byte) error {
+func (a *AstarteInterfaceAggregation) UnmarshalJSON(b []byte) error {
 	var j string
-	err := json.Unmarshal(b, &j)
-	if err != nil {
+	if err := json.Unmarshal(b, &j); err != nil {
 		return err
 	}
-	// Note that if the string cannot be found then it will be set to the zero value, 'IndividualAggregation' in this case.
-	*s = astarteInterfaceAggregationToID[j]
+
+	// Note that if the string is empty then it will be set to 'IndividualAggregation'
+	if j == "" {
+		*a = IndividualAggregation
+	} else {
+		*a = AstarteInterfaceAggregation(j)
+		if err := a.IsValid(); err != nil {
+			return fmt.Errorf("'%v' is not a valid Astarte Interface Aggregation", j)
+		}
+	}
 	return nil
 }
 
 // AstarteMappingReliability represents the reliability of a mapping
-type AstarteMappingReliability int
+type AstarteMappingReliability string
 
 const (
 	// UnreliableReliability represents a QoS 0-like reliability on the wire
-	UnreliableReliability AstarteMappingReliability = iota
+	UnreliableReliability AstarteMappingReliability = "unreliable"
 	// GuaranteedReliability represents a QoS 1-like reliability on the wire
-	GuaranteedReliability
+	GuaranteedReliability AstarteMappingReliability = "guaranteed"
 	// UniqueReliability represents a QoS 2-like reliability on the wire
-	UniqueReliability
+	UniqueReliability AstarteMappingReliability = "unique"
 )
 
-func (s AstarteMappingReliability) String() string {
-	return astarteMappingReliabilityToString[s]
-}
-
-var astarteMappingReliabilityToString = map[AstarteMappingReliability]string{
-	UnreliableReliability: "unreliable",
-	GuaranteedReliability: "guaranteed",
-	UniqueReliability:     "unique",
-}
-
-var astarteMappingReliabilityToID = map[string]AstarteMappingReliability{
-	"unreliable": UnreliableReliability,
-	"guaranteed": GuaranteedReliability,
-	"unique":     UniqueReliability,
-}
-
-// MarshalJSON marshals the enum as a quoted json string
-func (s AstarteMappingReliability) MarshalJSON() ([]byte, error) {
-	return json.Marshal(astarteMappingReliabilityToString[s])
+// IsValid returns an error if AstarteMappingReliability does not represent a valid Astarte Mapping Reliability
+func (r AstarteMappingReliability) IsValid() error {
+	switch r {
+	case UnreliableReliability, GuaranteedReliability, UniqueReliability:
+		return nil
+	}
+	return errors.New("invalid Astarte Mapping reliability")
 }
 
 // UnmarshalJSON unmashals a quoted json string to the enum value
-func (s *AstarteMappingReliability) UnmarshalJSON(b []byte) error {
+func (r *AstarteMappingReliability) UnmarshalJSON(b []byte) error {
 	var j string
-	err := json.Unmarshal(b, &j)
-	if err != nil {
+	if err := json.Unmarshal(b, &j); err != nil {
 		return err
 	}
-	// Note that if the string cannot be found then it will be set to the zero value, 'UnreliableReliability' in this case.
-	*s = astarteMappingReliabilityToID[j]
+
+	// Note that if the string is empty then it will be set to 'UnreliableReliability'
+	if j == "" {
+		*r = UnreliableReliability
+	} else {
+		*r = AstarteMappingReliability(j)
+		if err := r.IsValid(); err != nil {
+			return fmt.Errorf("'%v' is not a valid Astarte Mapping Reliability", j)
+		}
+	}
 	return nil
 }
 
 // AstarteMappingRetention represents retention for a single mapping
-type AstarteMappingRetention int
+type AstarteMappingRetention string
 
 const (
 	// DiscardRetention means the sample will be discarded if it cannot be sent
-	DiscardRetention AstarteMappingRetention = iota
+	DiscardRetention AstarteMappingRetention = "discard"
 	// VolatileRetention means the sample will be stored in RAM until possible if it cannot be sent
-	VolatileRetention
+	VolatileRetention AstarteMappingRetention = "volatile"
 	// StoredRetention means the sample will be stored on Disk until expiration if it cannot be sent
-	StoredRetention
+	StoredRetention AstarteMappingRetention = "stored"
 )
 
-func (s AstarteMappingRetention) String() string {
-	return astarteMappingRetentionToString[s]
-}
-
-var astarteMappingRetentionToString = map[AstarteMappingRetention]string{
-	DiscardRetention:  "discard",
-	VolatileRetention: "volatile",
-	StoredRetention:   "stored",
-}
-
-var astarteMappingRetentionToID = map[string]AstarteMappingRetention{
-	"discard":  DiscardRetention,
-	"volatile": VolatileRetention,
-	"stored":   StoredRetention,
-}
-
-// MarshalJSON marshals the enum as a quoted json string
-func (s AstarteMappingRetention) MarshalJSON() ([]byte, error) {
-	return json.Marshal(astarteMappingRetentionToString[s])
+// IsValid returns an error if AstarteMappingRetention does not represent a valid Astarte Mapping Retention
+func (r AstarteMappingRetention) IsValid() error {
+	switch r {
+	case DiscardRetention, VolatileRetention, StoredRetention:
+		return nil
+	}
+	return errors.New("invalid Astarte Mapping retention")
 }
 
 // UnmarshalJSON unmashals a quoted json string to the enum value
-func (s *AstarteMappingRetention) UnmarshalJSON(b []byte) error {
+func (r *AstarteMappingRetention) UnmarshalJSON(b []byte) error {
 	var j string
-	err := json.Unmarshal(b, &j)
-	if err != nil {
+	if err := json.Unmarshal(b, &j); err != nil {
 		return err
 	}
-	// Note that if the string cannot be found then it will be set to the zero value, 'DiscardRetention' in this case.
-	*s = astarteMappingRetentionToID[j]
+
+	// Note that if the string is empty then it will be set to 'DiscardRetention'
+	if j == "" {
+		*r = DiscardRetention
+	} else {
+		*r = AstarteMappingRetention(j)
+		if err := r.IsValid(); err != nil {
+			return fmt.Errorf("'%v' is not a valid Astarte Mapping Retention", j)
+		}
+	}
 	return nil
 }
 
 // AstarteMappingDatabaseRetentionPolicy represents database retention policy for a single mapping
-type AstarteMappingDatabaseRetentionPolicy int
+type AstarteMappingDatabaseRetentionPolicy string
 
 const (
 	// NoTTL means that there is no expiry (TTL)
-	NoTTL AstarteMappingDatabaseRetentionPolicy = iota
+	NoTTL AstarteMappingDatabaseRetentionPolicy = "no_ttl"
 	// UseTTL means that database retention TTL is used
-	UseTTL
+	UseTTL AstarteMappingDatabaseRetentionPolicy = "use_ttl"
 )
 
-func (s AstarteMappingDatabaseRetentionPolicy) String() string {
-	return astarteMappingDatabaseRetentionPolicyToString[s]
-}
-
-var astarteMappingDatabaseRetentionPolicyToString = map[AstarteMappingDatabaseRetentionPolicy]string{
-	NoTTL:  "no_ttl",
-	UseTTL: "use_ttl",
-}
-
-var astarteMappingDatabaseRetentionPolicyToID = map[string]AstarteMappingDatabaseRetentionPolicy{
-	"no_ttl":  NoTTL,
-	"use_ttl": UseTTL,
-}
-
-// MarshalJSON marshals the enum as a quoted json string
-func (s AstarteMappingDatabaseRetentionPolicy) MarshalJSON() ([]byte, error) {
-	return json.Marshal(astarteMappingDatabaseRetentionPolicyToString[s])
+// IsValid returns an error if AstarteMappingDatabaseRetentionPolicy does not represent a valid Astarte Mapping Database Retention Policy
+func (r AstarteMappingDatabaseRetentionPolicy) IsValid() error {
+	switch r {
+	case NoTTL, UseTTL:
+		return nil
+	}
+	return errors.New("invalid Astarte Mapping database retention policy")
 }
 
 // UnmarshalJSON unmashals a quoted json string to the enum value
-func (s *AstarteMappingDatabaseRetentionPolicy) UnmarshalJSON(b []byte) error {
+func (r *AstarteMappingDatabaseRetentionPolicy) UnmarshalJSON(b []byte) error {
 	var j string
-	err := json.Unmarshal(b, &j)
-	if err != nil {
+	if err := json.Unmarshal(b, &j); err != nil {
 		return err
 	}
-	// Note that if the string cannot be found then it will be set to the zero value, 'NoTTL' in this case.
-	*s = astarteMappingDatabaseRetentionPolicyToID[j]
+
+	// Note that if the string is empty then it will be set to 'NoTTL'
+	if j == "" {
+		*r = NoTTL
+	} else {
+		*r = AstarteMappingDatabaseRetentionPolicy(j)
+		if err := r.IsValid(); err != nil {
+			return fmt.Errorf("'%v' is not a valid Astarte Mapping Database Retention Policy", j)
+		}
+	}
 	return nil
 }
 
 // AstarteMappingType represents the type of a single mapping. Astarte Types are natively inferred from golang
 // native types, as long as the conversion does not lose precision, e.g.: an `int32` value will be accepted
 // as a "double" type, but a `float64` value won't be accepted as a "integer" type
-type AstarteMappingType int
+type AstarteMappingType string
 
 const (
 	// Double represents the "double" type in Astarte. It maps to golang `float64` type,
 	// but also accepts implicit conversions from any int or float type
-	Double AstarteMappingType = iota
+	Double AstarteMappingType = "double"
 	// Integer represents the "integer" type in Astarte. It maps to golang `int` type,
 	// but also accepts implicit conversions from any int type < 64bit
-	Integer
+	Integer AstarteMappingType = "integer"
 	// Boolean represents the "boolean" type in Astarte. It maps to golang `bool` type
-	Boolean
+	Boolean AstarteMappingType = "boolean"
 	// LongInteger represents the "longinteger" type in Astarte. It maps to golang `int64` type,
 	// but also accepts implicit conversions from any int type
-	LongInteger
+	LongInteger AstarteMappingType = "longinteger"
 	// String represents the "string" type in Astarte. It maps to golang `string` type
-	String
+	String AstarteMappingType = "string"
 	// BinaryBlob represents the "binaryblob" type in Astarte. It maps to golang `[]byte` type
-	BinaryBlob
+	BinaryBlob AstarteMappingType = "binaryblob"
 	// DateTime represents the "datetime" type in Astarte. It maps to golang `time.Time` type
-	DateTime
+	DateTime AstarteMappingType = "datetime"
 	// DoubleArray represents the "doublearray" type in Astarte. It maps to golang `[]float` type,
 	// but also accepts implicit conversions from any int or float type array
-	DoubleArray
+	DoubleArray AstarteMappingType = "doublearray"
 	// IntegerArray represents the "integerarray" type in Astarte. It maps to golang `[]int` type,
 	// but also accepts implicit conversions from any int type < 64bit
-	IntegerArray
+	IntegerArray AstarteMappingType = "integerarray"
 	// BooleanArray represents the "booleanarray" type in Astarte. It maps to golang `[]bool` type
-	BooleanArray
+	BooleanArray AstarteMappingType = "booleanarray"
 	// LongIntegerArray represents the "longintegerarray" type in Astarte. It maps to golang `[]int64` type,
 	// but also accepts implicit conversions from any int type
-	LongIntegerArray
+	LongIntegerArray AstarteMappingType = "longintegerarray"
 	// StringArray represents the "stringarray" type in Astarte. It maps to golang `[]string` type
-	StringArray
+	StringArray AstarteMappingType = "stringarray"
 	// BinaryBlobArray represents the "binaryblobarray" type in Astarte. It maps to golang `[]byte` type
-	BinaryBlobArray
+	BinaryBlobArray AstarteMappingType = "binaryblobarray"
 	// DateTimeArray represents the "datetimearray" type in Astarte. It maps to golang `[]time.Time` type
-	DateTimeArray
+	DateTimeArray AstarteMappingType = "datetimearray"
 )
 
-func (s AstarteMappingType) String() string {
-	return astarteMappingTypeToString[s]
-}
-
-var astarteMappingTypeToString = map[AstarteMappingType]string{
-	Double:           "double",
-	Integer:          "integer",
-	Boolean:          "boolean",
-	LongInteger:      "longinteger",
-	String:           "string",
-	BinaryBlob:       "binaryblob",
-	DateTime:         "datetime",
-	DoubleArray:      "doublearray",
-	IntegerArray:     "integerarray",
-	BooleanArray:     "booleanarray",
-	LongIntegerArray: "longintegerarray",
-	StringArray:      "stringarray",
-	BinaryBlobArray:  "binaryblobarray",
-	DateTimeArray:    "datetimearray",
-}
-
-var astarteMappingTypeToID = map[string]AstarteMappingType{
-	"double":           Double,
-	"integer":          Integer,
-	"boolean":          Boolean,
-	"longinteger":      LongInteger,
-	"string":           String,
-	"binaryblob":       BinaryBlob,
-	"datetime":         DateTime,
-	"doublearray":      DoubleArray,
-	"integerarray":     IntegerArray,
-	"booleanarray":     BooleanArray,
-	"longintegerarray": LongIntegerArray,
-	"stringarray":      StringArray,
-	"binaryblobarray":  BinaryBlobArray,
-	"datetimearray":    DateTimeArray,
-}
-
-// MarshalJSON marshals the enum as a quoted json string
-func (s AstarteMappingType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(astarteMappingTypeToString[s])
+// IsValid returns an error if AstarteMappingType does not represent a valid Astarte Mapping Type
+func (m AstarteMappingType) IsValid() error {
+	switch m {
+	case Double, Integer, Boolean, LongInteger, String, BinaryBlob, DateTime,
+		DoubleArray, IntegerArray, BooleanArray, LongIntegerArray, StringArray, BinaryBlobArray, DateTimeArray:
+		return nil
+	}
+	return errors.New("invalid Astarte Mapping type")
 }
 
 // UnmarshalJSON unmashals a quoted json string to the enum value
-func (s *AstarteMappingType) UnmarshalJSON(b []byte) error {
+func (m *AstarteMappingType) UnmarshalJSON(b []byte) error {
 	var j string
 	err := json.Unmarshal(b, &j)
 	if err != nil {
 		return err
 	}
-	// Return if found
-	if val, ok := astarteMappingTypeToID[j]; ok {
-		*s = val
-		return nil
-	}
 
-	// Fail if not found
-	return fmt.Errorf("%s is not a valid Astarte type", j)
+	*m = AstarteMappingType(j)
+	if err := m.IsValid(); err != nil {
+		return fmt.Errorf("'%v' is not a valid Astarte Mapping Type", j)
+	}
+	return nil
 }
 
 // AstarteInterfaceMapping represents an individual Mapping in an Astarte Interface

--- a/interfaces/astarte_interface_test.go
+++ b/interfaces/astarte_interface_test.go
@@ -38,7 +38,7 @@ func TestParsing(t *testing.T) {
 				"doc": "An arbitrary sensor name.",
 				"retention": "discard",
 				"reliability": "unreliable",
-				"database_retention_policy": "ttl",
+				"database_retention_policy": "use_ttl",
 				"database_retention_ttl": 200
 			},
 			{

--- a/interfaces/utils.go
+++ b/interfaces/utils.go
@@ -305,5 +305,5 @@ func validateType(mappingType AstarteMappingType, value interface{}) error {
 		}
 	}
 
-	return fmt.Errorf("Value for mapping does not match type restrictions for %s", mappingType.String())
+	return fmt.Errorf("Value for mapping does not match type restrictions for %s", mappingType)
 }

--- a/interfaces/utils_test.go
+++ b/interfaces/utils_test.go
@@ -42,7 +42,7 @@ func TestMessageValidation(t *testing.T) {
 				"doc": "An arbitrary sensor name.",
 				"retention": "discard",
 				"reliability": "unreliable",
-				"database_retention_policy": "ttl",
+				"database_retention_policy": "use_ttl",
 				"database_retention_ttl": 200
 			},
 			{
@@ -97,7 +97,7 @@ func TestParametricMessageWrongPaths(t *testing.T) {
 				"doc": "An arbitrary sensor name.",
 				"retention": "discard",
 				"reliability": "unreliable",
-				"database_retention_policy": "ttl",
+				"database_retention_policy": "use_ttl",
 				"database_retention_ttl": 200
 			},
 			{
@@ -155,7 +155,7 @@ func TestAggregateMessageValidation(t *testing.T) {
 				"doc": "An arbitrary sensor name.",
 				"retention": "discard",
 				"reliability": "unreliable",
-				"database_retention_policy": "ttl",
+				"database_retention_policy": "use_ttl",
 				"database_retention_ttl": 200
 			},
 			{
@@ -210,7 +210,7 @@ func TestAggregateMessageWrongPaths(t *testing.T) {
 				"doc": "An arbitrary sensor name.",
 				"retention": "discard",
 				"reliability": "unreliable",
-				"database_retention_policy": "ttl",
+				"database_retention_policy": "use_ttl",
 				"database_retention_ttl": 200
 			},
 			{


### PR DESCRIPTION
Go has very bad support for enums, but we managed to make it even worse. Use string-based enums and remove dangerous string constant duplication, and unify validation approach through IsValid(). This also fixed some bugs in JSON parsing.