### PR TITLE
Improve codebase quality, introduce golangci-lint

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,17 +26,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set up Go ${{ matrix.go }}
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
-      id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-    - name: Check gofmt
-      run: diff -u <(echo -n) <(gofmt -d ./...)
-      if: matrix.os != 'windows-latest'
-    - name: Run go vet
-      run: go vet $(go list ./... | grep -v /vendor/)
+    - uses: actions/checkout@v2
     - name: Build
       run: go build -v ./...
     - name: Test (with coverprofile)

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,37 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2020 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "Static code checking"
+on:
+  pull_request:
+  push:
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        # Ensure we're on Go 1.14
+        go-version: '1.14.x'
+    # Run golint-ci
+    - name: Run golangci-lint
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.25.1
+        ./bin/golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,184 @@
+# This file contains all available configuration options
+# with their default values.
+
+# options for analysis running
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  # Allow 10m, within actions it might take a lot
+  timeout: 10m
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
+  format: line-number
+
+# all available settings of specific linters
+linters-settings:
+  dogsled:
+    # checks assignments with too many blank identifiers; default is 2
+    max-blank-identifiers: 2
+  dupl:
+    # tokens count to trigger issue, 150 by default
+    threshold: 100
+  errcheck:
+    # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
+    # default is false: such cases aren't reported by default.
+    check-type-assertions: false
+
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+    # default is false: such cases aren't reported by default.
+    check-blank: false
+
+    # [deprecated] comma-separated list of pairs of the form pkg:regex
+    # the regex is used to ignore names within pkg. (default "fmt:.*").
+    # see https://github.com/kisielk/errcheck#the-deprecated-method for details
+    ignore: SetPrerelease
+  funlen:
+    lines: 120
+    statements: 40
+  gocognit:
+    # Keep 30, so we report only truly insane things. Reconciliation functions will always be
+    # a little bit more complex than needed
+    min-complexity: 30
+  goconst:
+    # minimal length of string constant, 3 by default
+    min-len: 3
+    # minimal occurrences count to trigger, 3 by default
+    min-occurrences: 3
+  gocritic:
+  gocyclo:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 15
+  godox:
+    # report any comments starting with keywords, this is useful for TODO or FIXME comments that
+    # might be left in the code accidentally and should be resolved before merging
+    keywords: # default keywords are TODO, BUG, and FIXME, these can be overwritten by this setting
+      - NOTE
+      - OPTIMIZE # marks code that should be optimized before merging
+      - HACK # marks hack-arounds that should be removed before merging
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: true
+  goimports:
+  golint:
+    # minimal confidence for issues, default is 0.8
+    min-confidence: 0.8
+  gomnd:
+    settings:
+      mnd:
+        # the list of enabled checks, see https://github.com/tommy-muehle/go-mnd/#checks for description.
+        checks: argument,case,condition,operation,return,assign
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+    enable-all: true
+  depguard:
+  lll:
+    # max line length, lines longer will be reported. Default is 120.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+    line-length: 120
+    # tab width in spaces. Default to 1.
+    tab-width: 1
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Default is to use a neutral variety of English.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    locale: US
+  nakedret:
+  prealloc:
+  rowserrcheck:
+  unparam:
+  unused:
+  whitespace:
+    multi-if: false   # Enforces newlines (or comments) after every multi-line if statement
+    multi-func: false # Enforces newlines (or comments) after every multi-line function signature
+  wsl:
+    # If true append is only allowed to be cuddled if appending value is
+    # matching variables, fields or types on line above. Default is true.
+    strict-append: true
+    # Allow calls and assignments to be cuddled as long as the lines have any
+    # matching variables, fields or types. Default is true.
+    allow-assign-and-call: true
+    # Allow multiline assignments to be cuddled. Default is true.
+    allow-multiline-assign: true
+    # Allow declarations (var) to be cuddled.
+    allow-cuddle-declarations: false
+    # Allow trailing comments in ending of blocks
+    allow-trailing-comment: false
+    # Force newlines in end of case at this limit (0 = never).
+    force-case-trailing-whitespace: 0
+    # Force cuddling of err checks with err var assignment
+    force-err-cuddling: false
+    # Allow leading comments to be separated with empty liens
+    allow-separated-leading-comment: false
+
+linters:
+  enable:
+    - bodyclose
+    - dupl
+    - funlen
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - golint
+    - gofmt
+    - goimports
+    - goprintffuncname
+    - gosec
+    #- lll
+    - maligned
+    - misspell
+    - prealloc
+    - scopelint
+    - unconvert
+    - unparam
+
+  fast: false
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - deadcode
+        - dupl
+        - errcheck
+        - funlen
+        - gocyclo
+        - gocritic
+        - gosec
+        - unused
+        - varcheck
+
+    # Exclude lll issues for long lines with go:generate
+    - linters:
+        - lll
+      source: "^//go:generate "
+
+    # Exclude unparam issues for expectedReturnCode, as we want it to be explicit.
+    - linters:
+        - unparam
+      source: "expectedReturnCode int"
+
+    # Validation functions have insane complexity, not much we can do about it
+    - linters:
+        - gocyclo
+        - funlen
+      source: "^func validateType"
+
+    # We might have some unused boilerplate functions
+    - linters:
+        - unused
+      source: "^func \\(c \\*Client\\) genericJSONDataAPI"
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0

--- a/client/api_types.go
+++ b/client/api_types.go
@@ -154,12 +154,12 @@ func (s *DatastreamAggregateValue) UnmarshalJSON(b []byte) error {
 	}
 
 	timestampInterface, _ := j.Get("timestamp")
-	switch timestampInterface.(type) {
+	switch v := timestampInterface.(type) {
 	case time.Time:
-		s.Timestamp = timestampInterface.(time.Time)
+		s.Timestamp = v
 	case string:
 		var err error
-		s.Timestamp, err = time.Parse(time.RFC3339Nano, timestampInterface.(string))
+		s.Timestamp, err = time.Parse(time.RFC3339Nano, v)
 		if err != nil {
 			return err
 		}

--- a/client/appengine_devices.go
+++ b/client/appengine_devices.go
@@ -39,19 +39,10 @@ const (
 func (s *AppEngineService) ListDevices(realm string) ([]string, error) {
 	callURL, _ := url.Parse(s.appEngineURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/devices", realm))
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return nil, err
-	}
-	var responseBody struct {
-		Data []string `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return nil, err
-	}
+	deviceList := []string{}
+	err := s.client.genericJSONDataAPIGET(&deviceList, callURL.String(), 200)
 
-	return responseBody.Data, nil
+	return deviceList, err
 }
 
 // GetDevice returns the DeviceDetails of a single Device in the Realm
@@ -59,19 +50,10 @@ func (s *AppEngineService) GetDevice(realm string, deviceIdentifier string, devi
 	resolvedDeviceIdentifierType := resolveDeviceIdentifierType(deviceIdentifier, deviceIdentifierType)
 	callURL, _ := url.Parse(s.appEngineURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/%s", realm, devicePath(deviceIdentifier, resolvedDeviceIdentifierType)))
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return DeviceDetails{}, err
-	}
-	var responseBody struct {
-		Data DeviceDetails `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return DeviceDetails{}, err
-	}
+	deviceDetails := DeviceDetails{}
+	err := s.client.genericJSONDataAPIGET(&deviceDetails, callURL.String(), 200)
 
-	return responseBody.Data, nil
+	return deviceDetails, err
 }
 
 // GetDeviceIDFromDeviceIdentifier returns the DeviceID of a Device identified with a deviceIdentifier
@@ -103,19 +85,10 @@ func (s *AppEngineService) ListDeviceInterfaces(realm string, deviceIdentifier s
 	resolvedDeviceIdentifierType := resolveDeviceIdentifierType(deviceIdentifier, deviceIdentifierType)
 	callURL, _ := url.Parse(s.appEngineURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/%s/interfaces", realm, devicePath(deviceIdentifier, resolvedDeviceIdentifierType)))
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return nil, err
-	}
-	var responseBody struct {
-		Data []string `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return nil, err
-	}
+	deviceInterfacesList := []string{}
+	err := s.client.genericJSONDataAPIGET(&deviceInterfacesList, callURL.String(), 200)
 
-	return responseBody.Data, nil
+	return deviceInterfacesList, err
 }
 
 // ListDeviceAliases is an helper to list all aliases of a Device
@@ -174,17 +147,8 @@ func (s *AppEngineService) InhibitDevice(realm string, deviceIdentifier string,
 func (s *AppEngineService) GetDevicesStats(realm string) (DevicesStats, error) {
 	callURL, _ := url.Parse(s.appEngineURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/stats/devices", realm))
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return DevicesStats{}, err
-	}
-	var responseBody struct {
-		Data DevicesStats `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return DevicesStats{}, err
-	}
+	deviceStats := DevicesStats{}
+	err := s.client.genericJSONDataAPIGET(&deviceStats, callURL.String(), 200)
 
-	return responseBody.Data, nil
+	return deviceStats, err
 }

--- a/client/appengine_groups.go
+++ b/client/appengine_groups.go
@@ -26,19 +26,10 @@ import (
 func (s *AppEngineService) ListGroups(realm string) ([]string, error) {
 	callURL, _ := url.Parse(s.appEngineURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/groups", realm))
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return nil, err
-	}
-	var responseBody struct {
-		Data []string `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return nil, err
-	}
+	groupsList := []string{}
+	err := s.client.genericJSONDataAPIGET(&groupsList, callURL.String(), 200)
 
-	return responseBody.Data, nil
+	return groupsList, err
 }
 
 // CreateGroup creates a group with the given deviceIdentifierList in the Realm
@@ -68,19 +59,10 @@ func (s *AppEngineService) CreateGroup(realm string, groupName string, deviceIde
 func (s *AppEngineService) ListGroupDevices(realm string, groupName string) ([]string, error) {
 	callURL, _ := url.Parse(s.appEngineURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/groups/%s/devices", realm, url.PathEscape(groupName)))
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return nil, err
-	}
-	var responseBody struct {
-		Data []string `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return nil, err
-	}
+	groupDevicesList := []string{}
+	err := s.client.genericJSONDataAPIGET(&groupDevicesList, callURL.String(), 200)
 
-	return responseBody.Data, nil
+	return groupDevicesList, err
 }
 
 // AddDeviceToGroup adds a device to the group

--- a/client/appengine_internal.go
+++ b/client/appengine_internal.go
@@ -109,8 +109,7 @@ func parseAggregateDatastreamMap(aMap orderedmap.OrderedMap, completeKeyPath str
 	foundAnything := false
 	for _, key := range aMap.Keys() {
 		val, _ := aMap.Get(key)
-		switch cVal := val.(type) {
-		case orderedmap.OrderedMap:
+		if cVal, ok := val.(orderedmap.OrderedMap); ok {
 			foundAnything = true
 			parsedMap, err := parseAggregateDatastreamMap(cVal, completeKeyPath+"/"+key)
 			if err != nil {
@@ -166,8 +165,7 @@ func parseDatastreamMap(aMap map[string]interface{}, completeKeyPath string) (ma
 
 	foundAnything := false
 	for key, val := range aMap {
-		switch cVal := val.(type) {
-		case map[string]interface{}:
+		if cVal, ok := val.(map[string]interface{}); ok {
 			foundAnything = true
 			parsedMap, err := parseDatastreamMap(cVal, completeKeyPath+"/"+key)
 			if err != nil {

--- a/client/astarte.go
+++ b/client/astarte.go
@@ -161,11 +161,11 @@ func (c *Client) SetTokenFromPrivateKeyFile(privateKeyFile string) error {
 func (c *Client) SetTokenFromPrivateKeyFileWithTTL(privateKeyFile string, ttlSeconds int64) error {
 	// Add all types
 	servicesAndClaims := map[misc.AstarteService][]string{
-		misc.AppEngine:       []string{},
-		misc.Channels:        []string{},
-		misc.Housekeeping:    []string{},
-		misc.Pairing:         []string{},
-		misc.RealmManagement: []string{},
+		misc.AppEngine:       {},
+		misc.Channels:        {},
+		misc.Housekeeping:    {},
+		misc.Pairing:         {},
+		misc.RealmManagement: {},
 	}
 	return c.SetTokenFromPrivateKeyFileWithClaims(privateKeyFile, servicesAndClaims, ttlSeconds)
 }
@@ -191,11 +191,11 @@ func (c *Client) SetTokenFromPrivateKey(privateKey []byte) error {
 func (c *Client) SetTokenFromPrivateKeyWithTTL(privateKey []byte, ttlSeconds int64) error {
 	// Add all types
 	servicesAndClaims := map[misc.AstarteService][]string{
-		misc.AppEngine:       []string{},
-		misc.Channels:        []string{},
-		misc.Housekeeping:    []string{},
-		misc.Pairing:         []string{},
-		misc.RealmManagement: []string{},
+		misc.AppEngine:       {},
+		misc.Channels:        {},
+		misc.Housekeeping:    {},
+		misc.Pairing:         {},
+		misc.RealmManagement: {},
 	}
 	return c.SetTokenFromPrivateKeyWithClaims(privateKey, servicesAndClaims, ttlSeconds)
 }

--- a/client/housekeeping.go
+++ b/client/housekeeping.go
@@ -31,38 +31,20 @@ type HousekeepingService struct {
 func (s *HousekeepingService) ListRealms() ([]string, error) {
 	callURL, _ := url.Parse(s.housekeepingURL.String())
 	callURL.Path = path.Join(callURL.Path, "/v1/realms")
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return nil, err
-	}
-	var responseBody struct {
-		Data []string `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return nil, err
-	}
+	realmsList := []string{}
+	err := s.client.genericJSONDataAPIGET(&realmsList, callURL.String(), 200)
 
-	return responseBody.Data, nil
+	return realmsList, err
 }
 
 // GetRealm returns data about a single Realm.
 func (s *HousekeepingService) GetRealm(realm string) (RealmDetails, error) {
 	callURL, _ := url.Parse(s.housekeepingURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/realms/%s", realm))
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return RealmDetails{}, err
-	}
-	var responseBody struct {
-		Data RealmDetails `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return RealmDetails{}, err
-	}
+	realmDetails := RealmDetails{}
+	err := s.client.genericJSONDataAPIGET(&realmDetails, callURL.String(), 200)
 
-	return responseBody.Data, nil
+	return realmDetails, err
 }
 
 // CreateRealm creates a new Realm in the Cluster with default parameters.

--- a/client/paginator.go
+++ b/client/paginator.go
@@ -81,12 +81,7 @@ func (d *DatastreamPaginator) GetNextPage() ([]DatastreamValue, error) {
 		return nil, err
 	}
 
-	if len(page) < d.pageSize {
-		d.hasNextPage = false
-	} else {
-		d.hasNextPage = true
-		d.nextWindow = page[len(page)-1].Timestamp
-	}
+	d.computePageState(len(page), page[len(page)-1].Timestamp)
 
 	return page, nil
 }
@@ -107,14 +102,18 @@ func (d *DatastreamPaginator) GetNextAggregatePage() ([]DatastreamAggregateValue
 		return nil, err
 	}
 
-	if len(page) < d.pageSize {
+	d.computePageState(len(page), page[len(page)-1].Timestamp)
+
+	return page, nil
+}
+
+func (d *DatastreamPaginator) computePageState(resultLength int, nextWindow time.Time) {
+	if resultLength < d.pageSize {
 		d.hasNextPage = false
 	} else {
 		d.hasNextPage = true
-		d.nextWindow = page[len(page)-1].Timestamp
+		d.nextWindow = nextWindow
 	}
-
-	return page, nil
 }
 
 func (d *DatastreamPaginator) setupCallURL() (*url.URL, error) {

--- a/client/paginator.go
+++ b/client/paginator.go
@@ -75,26 +75,20 @@ func (d *DatastreamPaginator) GetNextPage() ([]DatastreamValue, error) {
 
 	callURL, _ := d.setupCallURL()
 
-	decoder, err := d.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return nil, err
-	}
-	var responseBody struct {
-		Data []DatastreamValue `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
+	page := []DatastreamValue{}
+	err := d.client.genericJSONDataAPIGET(&page, callURL.String(), 200)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(responseBody.Data) < d.pageSize {
+	if len(page) < d.pageSize {
 		d.hasNextPage = false
 	} else {
 		d.hasNextPage = true
-		d.nextWindow = responseBody.Data[len(responseBody.Data)-1].Timestamp
+		d.nextWindow = page[len(page)-1].Timestamp
 	}
 
-	return responseBody.Data, nil
+	return page, nil
 }
 
 // GetNextAggregatePage retrieves the next result page from the paginator for an Aggregate interface.
@@ -107,26 +101,20 @@ func (d *DatastreamPaginator) GetNextAggregatePage() ([]DatastreamAggregateValue
 
 	callURL, _ := d.setupCallURL()
 
-	decoder, err := d.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return nil, err
-	}
-	var responseBody struct {
-		Data []DatastreamAggregateValue `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
+	page := []DatastreamAggregateValue{}
+	err := d.client.genericJSONDataAPIGET(&page, callURL.String(), 200)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(responseBody.Data) < d.pageSize {
+	if len(page) < d.pageSize {
 		d.hasNextPage = false
 	} else {
 		d.hasNextPage = true
-		d.nextWindow = responseBody.Data[len(responseBody.Data)-1].Timestamp
+		d.nextWindow = page[len(page)-1].Timestamp
 	}
 
-	return responseBody.Data, nil
+	return page, nil
 }
 
 func (d *DatastreamPaginator) setupCallURL() (*url.URL, error) {

--- a/client/pairing.go
+++ b/client/pairing.go
@@ -38,21 +38,10 @@ func (s *PairingService) RegisterDevice(realm string, deviceID string) (string, 
 	}
 	requestBody.HwID = deviceID
 
-	decoder, err := s.client.genericJSONDataAPIPostWithResponse(callURL.String(), requestBody, 201)
-	if err != nil {
-		return "", err
-	}
+	ret := deviceRegistrationResponse{}
+	err := s.client.genericJSONDataAPIPostWithResponse(&ret, callURL.String(), requestBody, 201)
 
-	// Decode the reply
-	var responseBody struct {
-		Data deviceRegistrationResponse `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return "", err
-	}
-
-	return responseBody.Data.CredentialsSecret, nil
+	return ret.CredentialsSecret, err
 }
 
 // UnregisterDevice resets the registration state of a device. This makes it possible to register it again.
@@ -81,21 +70,10 @@ func (s *PairingService) ObtainNewMQTTv1CertificateForDevice(realm, deviceID, cs
 	}
 	requestBody.CSR = csr
 
-	decoder, err := s.client.genericJSONDataAPIPostWithResponse(callURL.String(), requestBody, 201)
-	if err != nil {
-		return "", err
-	}
+	ret := getMQTTv1CertificateResponse{}
+	err := s.client.genericJSONDataAPIPostWithResponse(&ret, callURL.String(), requestBody, 201)
 
-	// Decode the reply
-	var responseBody struct {
-		Data getMQTTv1CertificateResponse `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return "", err
-	}
-
-	return responseBody.Data.ClientCertificate, nil
+	return ret.ClientCertificate, err
 }
 
 // GetMQTTv1ProtocolInformationForDevice returns protocol information (such as the broker URL) for devices running
@@ -106,19 +84,8 @@ func (s *PairingService) GetMQTTv1ProtocolInformationForDevice(realm, deviceID s
 	callURL, _ := url.Parse(s.pairingURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/devices/%s", realm, deviceID))
 
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return AstarteMQTTv1ProtocolInformation{}, err
-	}
+	ret := AstarteMQTTv1ProtocolInformation{}
+	err := s.client.genericJSONDataAPIGET(&ret, callURL.String(), 200)
 
-	// Decode the reply
-	var responseBody struct {
-		Data getDeviceProtocolStatusResponse `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return AstarteMQTTv1ProtocolInformation{}, err
-	}
-
-	return responseBody.Data.Protocols.AstarteMQTTv1, nil
+	return ret, err
 }

--- a/client/pairing.go
+++ b/client/pairing.go
@@ -84,8 +84,8 @@ func (s *PairingService) GetMQTTv1ProtocolInformationForDevice(realm, deviceID s
 	callURL, _ := url.Parse(s.pairingURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/devices/%s", realm, deviceID))
 
-	ret := AstarteMQTTv1ProtocolInformation{}
+	ret := getDeviceProtocolStatusResponse{}
 	err := s.client.genericJSONDataAPIGET(&ret, callURL.String(), 200)
 
-	return ret, err
+	return ret.Protocols.AstarteMQTTv1, err
 }

--- a/client/realm_management.go
+++ b/client/realm_management.go
@@ -32,57 +32,33 @@ type RealmManagementService struct {
 func (s *RealmManagementService) ListInterfaces(realm string) ([]string, error) {
 	callURL, _ := url.Parse(s.realmManagementURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/interfaces", realm))
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return nil, err
-	}
-	var responseBody struct {
-		Data []string `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return nil, err
-	}
 
-	return responseBody.Data, nil
+	interfacesList := []string{}
+	err := s.client.genericJSONDataAPIGET(&interfacesList, callURL.String(), 200)
+
+	return interfacesList, err
 }
 
 // ListInterfaceMajorVersions returns all available major versions for a given Interface in a Realm.
 func (s *RealmManagementService) ListInterfaceMajorVersions(realm string, interfaceName string) ([]int, error) {
 	callURL, _ := url.Parse(s.realmManagementURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/interfaces/%s", realm, interfaceName))
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return nil, err
-	}
-	var responseBody struct {
-		Data []int `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return nil, err
-	}
 
-	return responseBody.Data, nil
+	interfaceMajorVersions := []int{}
+	err := s.client.genericJSONDataAPIGET(&interfaceMajorVersions, callURL.String(), 200)
+
+	return interfaceMajorVersions, err
 }
 
 // GetInterface returns an interface, identified by a Major version, in a Realm
 func (s *RealmManagementService) GetInterface(realm string, interfaceName string, interfaceMajor int) (interfaces.AstarteInterface, error) {
 	callURL, _ := url.Parse(s.realmManagementURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/interfaces/%s/%v", realm, interfaceName, interfaceMajor))
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return interfaces.AstarteInterface{}, err
-	}
-	var responseBody struct {
-		Data interfaces.AstarteInterface `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return interfaces.AstarteInterface{}, err
-	}
 
-	return interfaces.EnsureInterfaceDefaults(responseBody.Data), nil
+	iface := interfaces.AstarteInterface{}
+	err := s.client.genericJSONDataAPIGET(&iface, callURL.String(), 200)
+
+	return interfaces.EnsureInterfaceDefaults(iface), err
 }
 
 // InstallInterface installs a new major version of an Interface into the Realm
@@ -110,38 +86,22 @@ func (s *RealmManagementService) UpdateInterface(realm string, interfaceName str
 func (s *RealmManagementService) ListTriggers(realm string) ([]string, error) {
 	callURL, _ := url.Parse(s.realmManagementURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/triggers", realm))
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return nil, err
-	}
-	var responseBody struct {
-		Data []string `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return nil, err
-	}
 
-	return responseBody.Data, nil
+	triggers := []string{}
+	err := s.client.genericJSONDataAPIGET(&triggers, callURL.String(), 200)
+
+	return triggers, err
 }
 
 // GetTrigger returns a trigger installed in a Realm
 func (s *RealmManagementService) GetTrigger(realm string, triggerName string) (map[string]interface{}, error) {
 	callURL, _ := url.Parse(s.realmManagementURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/triggers/%s", realm, triggerName))
-	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), 200)
-	if err != nil {
-		return nil, err
-	}
-	var responseBody struct {
-		Data map[string]interface{} `json:"data"`
-	}
-	err = decoder.Decode(&responseBody)
-	if err != nil {
-		return nil, err
-	}
 
-	return responseBody.Data, nil
+	trigger := map[string]interface{}{}
+	err := s.client.genericJSONDataAPIGET(&trigger, callURL.String(), 200)
+
+	return trigger, err
 }
 
 // InstallTrigger installs a Trigger into the Realm

--- a/interfaces/astarte_interface_test.go
+++ b/interfaces/astarte_interface_test.go
@@ -74,7 +74,7 @@ func TestMarshaling(t *testing.T) {
 		Description:   "Describes available generic sensors.",
 		Documentation: "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.",
 		Mappings: []AstarteInterfaceMapping{
-			AstarteInterfaceMapping{
+			{
 				Endpoint:                "/%{sensor_id}/name",
 				Type:                    String,
 				Description:             "Sensor name.",
@@ -84,7 +84,7 @@ func TestMarshaling(t *testing.T) {
 				DatabaseRetentionPolicy: UseTTL,
 				DatabaseRetentionTTL:    30000,
 			},
-			AstarteInterfaceMapping{
+			{
 				Endpoint:      "/%{sensor_id}/unit",
 				Type:          String,
 				Description:   "Sample data measurement unit.",

--- a/interfaces/utils_test.go
+++ b/interfaces/utils_test.go
@@ -397,7 +397,7 @@ func TestTypeValidation(t *testing.T) {
 	if err := ValidateIndividualMessage(i, "/booleanarrayValue", []bool{true}); err != nil {
 		t.Error(err)
 	}
-	if err := ValidateIndividualMessage(i, "/binaryblobarrayValue", [][]byte{[]byte{'b', 'l', 'o', 'b'}}); err != nil {
+	if err := ValidateIndividualMessage(i, "/binaryblobarrayValue", [][]byte{{'b', 'l', 'o', 'b'}}); err != nil {
 		t.Error(err)
 	}
 	if err := ValidateIndividualMessage(i, "/datetimearrayValue", []time.Time{timestamp}); err != nil {


### PR DESCRIPTION
This PR does two main things:

 * Vastly improves all the client module by ensuring that we don't need to create an enclosed struct for each return type, but we rather use json.Decoder in a clever way. As a side effect, we now also close correctly all return payloads.
 * Integrates golangci-lint and closes any pending issue within the codebase.