### PR TITLE
Fix Attributes naming + update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Changed
+- Replace device `metadata` with `attributes`.
+
+## [0.90.1] - 2021-03-03
+### Changed
+- Update dependencies
+
+## [0.90.0] - 2021-03-02
+### Added
+- Initial release

--- a/client/appengine_devices.go
+++ b/client/appengine_devices.go
@@ -221,12 +221,12 @@ func (s *AppEngineService) ListDeviceAttributes(realm, deviceIdentifier string, 
 	return deviceDetails.Attributes, nil
 }
 
-// SetDeviceAttributes sets an Attributes key to a certain value for a Device
-func (s *AppEngineService) SetDeviceAttributes(realm, deviceIdentifier string, deviceIdentifierType DeviceIdentifierType, attributesKey, attributesValue string) error {
+// SetDeviceAttribute sets an Attribute key to a certain value for a Device
+func (s *AppEngineService) SetDeviceAttribute(realm, deviceIdentifier string, deviceIdentifierType DeviceIdentifierType, attributeKey, attributeValue string) error {
 	resolvedDeviceIdentifierType := resolveDeviceIdentifierType(deviceIdentifier, deviceIdentifierType)
 	callURL, _ := url.Parse(s.appEngineURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/%s", realm, devicePath(deviceIdentifier, resolvedDeviceIdentifierType)))
-	payload := map[string]map[string]string{"attributes": {attributesKey: attributesValue}}
+	payload := map[string]map[string]string{"attributes": {attributeKey: attributeValue}}
 	err := s.client.genericJSONDataAPIPatch(callURL.String(), payload, 200)
 	if err != nil {
 		return err
@@ -235,14 +235,14 @@ func (s *AppEngineService) SetDeviceAttributes(realm, deviceIdentifier string, d
 	return nil
 }
 
-// DeleteDeviceAttributes deletes an Attributes key and its value from a Device
-func (s *AppEngineService) DeleteDeviceAttributes(realm, deviceIdentifier string, deviceIdentifierType DeviceIdentifierType, attributesKey string) error {
+// DeleteDeviceAttribute deletes an Attribute key and its value from a Device
+func (s *AppEngineService) DeleteDeviceAttribute(realm, deviceIdentifier string, deviceIdentifierType DeviceIdentifierType, attributeKey string) error {
 	resolvedDeviceIdentifierType := resolveDeviceIdentifierType(deviceIdentifier, deviceIdentifierType)
 	callURL, _ := url.Parse(s.appEngineURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/%s/%s", realm, devicePath(deviceIdentifier, resolvedDeviceIdentifierType)))
 	// We're using map[string]interface{} rather than map[string]string since we want to have null
 	// rather than an empty string in the JSON payload, and this is the only way.
-	payload := map[string]map[string]interface{}{"attributes": {attributesKey: nil}}
+	payload := map[string]map[string]interface{}{"attributes": {attributeKey: nil}}
 	err := s.client.genericJSONDataAPIPatch(callURL.String(), payload, 200)
 	if err != nil {
 		return err


### PR DESCRIPTION
- When dealing with a single device attribute use the singular. Use the plural otherwise.
- Update the changelog.