### PR TITLE
Interfaces: add validations for required fields

### DIFF
--- a/interfaces/astarte_interface_test.go
+++ b/interfaces/astarte_interface_test.go
@@ -62,6 +62,372 @@ func TestParsing(t *testing.T) {
 	if i.Mappings[1].Retention != DiscardRetention {
 		t.Error("Wrong retention detected", i.Mappings[0].Retention)
 	}
+
+	missingInterfaceName := `
+	{
+		"version_major": 0,
+		"version_minor": 1,
+		"type": "properties",
+		"ownership": "device",
+		"description": "Describes available generic sensors.",
+		"doc": "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.",
+		"mappings": [
+			{
+				"endpoint": "/%{sensor_id}/name",
+				"type": "string",
+				"description": "Sensor name.",
+				"doc": "An arbitrary sensor name.",
+				"retention": "discard",
+				"reliability": "unreliable",
+				"database_retention_policy": "use_ttl",
+				"database_retention_ttl": 200
+			},
+			{
+				"endpoint": "/%{sensor_id}/unit",
+				"type": "string",
+				"description": "Sample data measurement unit.",
+				"doc": "SI unit such as m, kg, K, etc..."
+			}
+		]
+	}`
+
+	_, err = ParseInterfaceFromString(missingInterfaceName)
+	if err == nil {
+		t.Error("This interface should have failed validation! Missing interface_name")
+	}
+
+	emptyInterfaceName := `
+	{
+                "interface_name": "",
+		"version_major": 0,
+		"version_minor": 1,
+		"type": "properties",
+		"ownership": "device",
+		"description": "Describes available generic sensors.",
+		"doc": "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.",
+		"mappings": [
+			{
+				"endpoint": "/%{sensor_id}/name",
+				"type": "string",
+				"description": "Sensor name.",
+				"doc": "An arbitrary sensor name.",
+				"retention": "discard",
+				"reliability": "unreliable",
+				"database_retention_policy": "use_ttl",
+				"database_retention_ttl": 200
+			},
+			{
+				"endpoint": "/%{sensor_id}/unit",
+				"type": "string",
+				"description": "Sample data measurement unit.",
+				"doc": "SI unit such as m, kg, K, etc..."
+			}
+		]
+	}`
+
+	_, err = ParseInterfaceFromString(emptyInterfaceName)
+	if err == nil {
+		t.Error("This interface should have failed validation! Missing interface_name")
+	}
+
+	missingInterfaceMajor := `
+	{
+		"interface_name": "org.astarte-platform.genericsensors.AvailableSensors",
+		"version_minor": 1,
+		"type": "properties",
+		"ownership": "device",
+		"description": "Describes available generic sensors.",
+		"doc": "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.",
+		"mappings": [
+			{
+				"endpoint": "/%{sensor_id}/name",
+				"type": "string",
+				"description": "Sensor name.",
+				"doc": "An arbitrary sensor name.",
+				"retention": "discard",
+				"reliability": "unreliable",
+				"database_retention_policy": "use_ttl",
+				"database_retention_ttl": 200
+			},
+			{
+				"endpoint": "/%{sensor_id}/unit",
+				"type": "string",
+				"description": "Sample data measurement unit.",
+				"doc": "SI unit such as m, kg, K, etc..."
+			}
+		]
+	}`
+
+	_, err = ParseInterfaceFromString(missingInterfaceMajor)
+	if err == nil {
+		t.Error("This interface should have failed validation! Missing interface_major")
+	}
+
+	missingInterfaceMinor := `
+	{
+		"interface_name": "org.astarte-platform.genericsensors.AvailableSensors",
+		"version_major": 1,
+		"type": "properties",
+		"ownership": "device",
+		"description": "Describes available generic sensors.",
+		"doc": "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.",
+		"mappings": [
+			{
+				"endpoint": "/%{sensor_id}/name",
+				"type": "string",
+				"description": "Sensor name.",
+				"doc": "An arbitrary sensor name.",
+				"retention": "discard",
+				"reliability": "unreliable",
+				"database_retention_policy": "use_ttl",
+				"database_retention_ttl": 200
+			},
+			{
+				"endpoint": "/%{sensor_id}/unit",
+				"type": "string",
+				"description": "Sample data measurement unit.",
+				"doc": "SI unit such as m, kg, K, etc..."
+			}
+		]
+	}`
+
+	_, err = ParseInterfaceFromString(missingInterfaceMinor)
+	if err == nil {
+		t.Error("This interface should have failed validation! Missing interface_minor")
+	}
+
+	missingInterfaceType := `
+	{
+		"interface_name": "org.astarte-platform.genericsensors.AvailableSensors",
+		"version_major": 1,
+		"version_minor": 0,
+		"ownership": "device",
+		"description": "Describes available generic sensors.",
+		"doc": "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.",
+		"mappings": [
+			{
+				"endpoint": "/%{sensor_id}/name",
+				"type": "string",
+				"description": "Sensor name.",
+				"doc": "An arbitrary sensor name.",
+				"retention": "discard",
+				"reliability": "unreliable",
+				"database_retention_policy": "use_ttl",
+				"database_retention_ttl": 200
+			},
+			{
+				"endpoint": "/%{sensor_id}/unit",
+				"type": "string",
+				"description": "Sample data measurement unit.",
+				"doc": "SI unit such as m, kg, K, etc..."
+			}
+		]
+	}`
+
+	_, err = ParseInterfaceFromString(missingInterfaceType)
+	if err == nil {
+		t.Error("This interface should have failed validation! Missing type")
+	}
+
+	missingInterfaceOwnership := `
+	{
+		"interface_name": "org.astarte-platform.genericsensors.AvailableSensors",
+		"version_major": 1,
+		"version_minor": 0,
+		"type": "properties",
+		"description": "Describes available generic sensors.",
+		"doc": "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.",
+		"mappings": [
+			{
+				"endpoint": "/%{sensor_id}/name",
+				"type": "string",
+				"description": "Sensor name.",
+				"doc": "An arbitrary sensor name.",
+				"retention": "discard",
+				"reliability": "unreliable",
+				"database_retention_policy": "use_ttl",
+				"database_retention_ttl": 200
+			},
+			{
+				"endpoint": "/%{sensor_id}/unit",
+				"type": "string",
+				"description": "Sample data measurement unit.",
+				"doc": "SI unit such as m, kg, K, etc..."
+			}
+		]
+	}`
+
+	_, err = ParseInterfaceFromString(missingInterfaceOwnership)
+	if err == nil {
+		t.Error("This interface should have failed validation! Missing ownership")
+	}
+
+	missingInterfaceMappings := `
+	{
+		"interface_name": "org.astarte-platform.genericsensors.AvailableSensors",
+		"version_major": 1,
+		"version_minor": 0,
+		"type": "properties",
+		"ownership": "device",
+		"description": "Describes available generic sensors.",
+		"doc": "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors."
+	}`
+
+	_, err = ParseInterfaceFromString(missingInterfaceMappings)
+	if err == nil {
+		t.Error("This interface should have failed validation! Missing interface mappings")
+	}
+
+	emptyInterfaceMappings := `
+	{
+		"interface_name": "org.astarte-platform.genericsensors.AvailableSensors",
+		"version_major": 1,
+		"version_minor": 0,
+		"type": "properties",
+		"ownership": "device",
+		"description": "Describes available generic sensors.",
+		"doc": "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.",
+                "mappings": []
+	}`
+
+	_, err = ParseInterfaceFromString(emptyInterfaceMappings)
+	if err == nil {
+		t.Error("This interface should have failed validation! Empty interface mappings")
+	}
+
+	missingInterfaceMappingEndpoint := `
+	{
+		"interface_name": "org.astarte-platform.genericsensors.AvailableSensors",
+		"version_major": 1,
+		"version_minor": 0,
+		"type": "properties",
+		"ownership": "device",
+		"description": "Describes available generic sensors.",
+		"doc": "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.",
+		"mappings": [
+			{
+				"type": "string",
+				"description": "Sensor name.",
+				"doc": "An arbitrary sensor name.",
+				"retention": "discard",
+				"reliability": "unreliable",
+				"database_retention_policy": "use_ttl",
+				"database_retention_ttl": 200
+			},
+			{
+				"endpoint": "/%{sensor_id}/unit",
+				"type": "string",
+				"description": "Sample data measurement unit.",
+				"doc": "SI unit such as m, kg, K, etc..."
+			}
+		]
+	}`
+
+	_, err = ParseInterfaceFromString(missingInterfaceMappingEndpoint)
+	if err == nil {
+		t.Error("This interface should have failed validation! Missing endpoint in interface mapping")
+	}
+
+	emptyInterfaceMappingEndpoint := `
+	{
+		"interface_name": "org.astarte-platform.genericsensors.AvailableSensors",
+		"version_major": 1,
+		"version_minor": 0,
+		"type": "properties",
+		"ownership": "device",
+		"description": "Describes available generic sensors.",
+		"doc": "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.",
+		"mappings": [
+			{
+                                "endpoint": "",
+				"type": "string",
+				"description": "Sensor name.",
+				"doc": "An arbitrary sensor name.",
+				"retention": "discard",
+				"reliability": "unreliable",
+				"database_retention_policy": "use_ttl",
+				"database_retention_ttl": 200
+			},
+			{
+				"endpoint": "/%{sensor_id}/unit",
+				"type": "string",
+				"description": "Sample data measurement unit.",
+				"doc": "SI unit such as m, kg, K, etc..."
+			}
+		]
+	}`
+
+	_, err = ParseInterfaceFromString(emptyInterfaceMappingEndpoint)
+	if err == nil {
+		t.Error("This interface should have failed validation! Empty endpoint in interface mapping")
+	}
+
+	wrongInterfaceMappingType := `
+	{
+		"interface_name": "org.astarte-platform.genericsensors.AvailableSensors",
+		"version_major": 1,
+		"version_minor": 0,
+		"type": "properties",
+		"ownership": "device",
+		"description": "Describes available generic sensors.",
+		"doc": "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.",
+		"mappings": [
+			{
+                                "endpoint": "/%{sensor_id}/name",
+				"type": "invalid",
+				"description": "Sensor name.",
+				"doc": "An arbitrary sensor name.",
+				"retention": "discard",
+				"reliability": "unreliable",
+				"database_retention_policy": "use_ttl",
+				"database_retention_ttl": 200
+			},
+			{
+				"endpoint": "/%{sensor_id}/unit",
+				"type": "string",
+				"description": "Sample data measurement unit.",
+				"doc": "SI unit such as m, kg, K, etc..."
+			}
+		]
+	}`
+
+	_, err = ParseInterfaceFromString(wrongInterfaceMappingType)
+	if err == nil {
+		t.Error("This interface should have failed validation! Wrong type in interface mapping")
+	}
+
+	missingInterfaceMappingType := `
+	{
+		"interface_name": "org.astarte-platform.genericsensors.AvailableSensors",
+		"version_major": 1,
+		"version_minor": 0,
+		"type": "properties",
+		"ownership": "device",
+		"description": "Describes available generic sensors.",
+		"doc": "This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.",
+		"mappings": [
+			{
+                                "endpoint": "/%{sensor_id}/name",
+				"description": "Sensor name.",
+				"doc": "An arbitrary sensor name.",
+				"retention": "discard",
+				"reliability": "unreliable",
+				"database_retention_policy": "use_ttl",
+				"database_retention_ttl": 200
+			},
+			{
+				"endpoint": "/%{sensor_id}/unit",
+				"type": "string",
+				"description": "Sample data measurement unit.",
+				"doc": "SI unit such as m, kg, K, etc..."
+			}
+		]
+	}`
+
+	_, err = ParseInterfaceFromString(missingInterfaceMappingType)
+	if err == nil {
+		t.Error("This interface should have failed validation! Missing type in interface mapping")
+	}
 }
 
 func TestMarshaling(t *testing.T) {


### PR DESCRIPTION
When parsing an Astarte interface, ensure that required fields are valid. 