### PR TITLE
Upgrade Go to 1.17

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         go:
-        - 1.13.x
-        - 1.14.x
+        - 1.17.x
+        - 1.18.x
         os:
         - ubuntu-latest
         - macos-latest
@@ -33,11 +33,11 @@ jobs:
       run: go build -v ./...
     - name: Test (with coverprofile)
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
-      if: matrix.os == 'ubuntu-latest' && matrix.go == '1.14.x'
+      if: matrix.os == 'ubuntu-latest' && matrix.go == '1.17.x'
     - name: Test (no coverprofile)
       run: go test -v -race ./...
-      if: matrix.os != 'ubuntu-latest' || matrix.go != '1.14.x'
+      if: matrix.os != 'ubuntu-latest' || matrix.go != '1.17.x'
     # Upload coverage report only in one case of the matrix
     - name: Upload coverage report
       uses: codecov/codecov-action@v1
-      if: matrix.os == 'ubuntu-latest' && matrix.go == '1.14.x'
+      if: matrix.os == 'ubuntu-latest' && matrix.go == '1.17.x'

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -28,8 +28,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        # Ensure we're on Go 1.14
-        go-version: '1.14.x'
+        # Ensure we're on Go 1.17
+        go-version: '1.17.x'
     # Run golint-ci
     - name: Run golangci-lint
       run: |

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This is the main dependency module for all Astarte Go applications and SDKs.
 
-Astarte Go requires at least Go 1.13.
+Astarte Go requires at least Go 1.17.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/astarte-platform/astarte-go
 
-go 1.13
+go 1.17
 
 require (
 	github.com/cristalhq/jwt/v3 v3.1.0


### PR DESCRIPTION
Go 1.13 is no more supported. Bump Go to a supported version.