### PR TITLE
 Unpack `misc` package

### DIFF
--- a/astarteservices/astarte_service_type.go
+++ b/astarteservices/astarte_service_type.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package misc
+package astarteservices
 
 import (
 	"errors"
@@ -23,19 +23,19 @@ type AstarteService int
 
 const (
 	// Unknown Astarte Service
-	Unknown AstarteService = 0
+	Unknown AstarteService = iota
 	// Housekeeping is Astarte's service for managing Realms
-	Housekeeping AstarteService = 1
+	Housekeeping
 	// RealmManagement is Astarte's service for managing configuration of a Realm
-	RealmManagement AstarteService = 2
+	RealmManagement
 	// Pairing is Astarte's service for managing device provisioning and access
-	Pairing AstarteService = 3
+	Pairing
 	// AppEngine is Astarte's service for interacting with Devices, Groups and more
-	AppEngine AstarteService = 4
+	AppEngine
 	// Channels is Astarte's service for WebSockets
-	Channels AstarteService = 5
+	Channels
 	// Flow is Astarte Flow
-	Flow AstarteService = 6
+	Flow
 )
 
 var astarteServiceValidNames = map[string]AstarteService{
@@ -51,7 +51,7 @@ var astarteServiceValidNames = map[string]AstarteService{
 	"flow":             Flow,
 }
 
-func (astarteService AstarteService) String() string {
+func (service AstarteService) String() string {
 	names := [...]string{
 		"",
 		"housekeeping",
@@ -61,15 +61,15 @@ func (astarteService AstarteService) String() string {
 		"channels",
 		"flow"}
 
-	if astarteService < Housekeeping || astarteService > Flow {
+	if service < Housekeeping || service > Flow {
 		return ""
 	}
 
-	return names[astarteService]
+	return names[service]
 }
 
-// AstarteServiceFromString returns a valid AstarteService out of a string
-func AstarteServiceFromString(astarteServiceString string) (AstarteService, error) {
+// FromString returns a valid AstarteService out of a string
+func FromString(astarteServiceString string) (AstarteService, error) {
 	if value, exist := astarteServiceValidNames[astarteServiceString]; exist {
 		return value, nil
 	}

--- a/auth/token.go
+++ b/auth/token.go
@@ -25,7 +25,7 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/astarte-platform/astarte-go/misc"
+	"github.com/astarte-platform/astarte-go/astarteservices"
 	jwt "github.com/cristalhq/jwt/v3"
 )
 
@@ -56,7 +56,7 @@ func (u *AstarteClaims) MarshalBinary() ([]byte, error) {
 // GenerateAstarteJWTFromKeyFile generates an Astarte Token for a specific API out of a Private Key File.
 // servicesAndClaims specifies which services with which claims the token will be authorized to access. Leaving
 // a claim empty will imply `.*::.*`, aka access to the entirety of the service's API tree
-func GenerateAstarteJWTFromKeyFile(privateKeyFile string, servicesAndClaims map[misc.AstarteService][]string,
+func GenerateAstarteJWTFromKeyFile(privateKeyFile string, servicesAndClaims map[astarteservices.AstarteService][]string,
 	ttlSeconds int64) (jwtString string, err error) {
 	keyPEM, err := ioutil.ReadFile(privateKeyFile)
 	if err != nil {
@@ -108,7 +108,7 @@ func ParsePrivateKeyFromPEM(key []byte) (interface{}, error) {
 // GenerateAstarteJWTFromPEMKey generates an Astarte Token for a specific API out of a Private Key PEM bytearray.
 // servicesAndClaims specifies which services with which claims the token will be authorized to access. Leaving
 // a claim empty will imply `.*::.*`, aka access to the entirety of the service's API tree
-func GenerateAstarteJWTFromPEMKey(privateKeyPEM []byte, servicesAndClaims map[misc.AstarteService][]string,
+func GenerateAstarteJWTFromPEMKey(privateKeyPEM []byte, servicesAndClaims map[astarteservices.AstarteService][]string,
 	ttlSeconds int64) (jwtString string, err error) {
 	key, err := ParsePrivateKeyFromPEM(privateKeyPEM)
 	if err != nil {
@@ -128,7 +128,7 @@ func GenerateAstarteJWTFromPEMKey(privateKeyPEM []byte, servicesAndClaims map[mi
 	for svc, c := range servicesAndClaims {
 		if len(c) == 0 {
 			switch svc {
-			case misc.Channels:
+			case astarteservices.Channels:
 				c = []string{"JOIN::.*", "WATCH::.*"}
 			default:
 				c = []string{".*::.*"}
@@ -136,17 +136,17 @@ func GenerateAstarteJWTFromPEMKey(privateKeyPEM []byte, servicesAndClaims map[mi
 		}
 
 		switch svc {
-		case misc.AppEngine:
+		case astarteservices.AppEngine:
 			claims.AppEngineAPI = c
-		case misc.Channels:
+		case astarteservices.Channels:
 			claims.Channels = c
-		case misc.Flow:
+		case astarteservices.Flow:
 			claims.Flow = c
-		case misc.Housekeeping:
+		case astarteservices.Housekeeping:
 			claims.Housekeeping = c
-		case misc.Pairing:
+		case astarteservices.Pairing:
 			claims.Pairing = c
-		case misc.RealmManagement:
+		case astarteservices.RealmManagement:
 			claims.RealmManagement = c
 		}
 	}
@@ -182,23 +182,23 @@ func GetJWTAstarteClaims(rawToken string) (AstarteClaims, error) {
 }
 
 // IsJWTAstarteClaimValidForService verifies that an Astarte Token has access to a given Astarte service.
-func IsJWTAstarteClaimValidForService(token string, service misc.AstarteService) (bool, error) {
+func IsJWTAstarteClaimValidForService(token string, service astarteservices.AstarteService) (bool, error) {
 	claims, err := GetJWTAstarteClaims(token)
 	if err != nil {
 		return false, err
 	}
 	switch service {
-	case misc.AppEngine:
+	case astarteservices.AppEngine:
 		return hasAuth(claims.AppEngineAPI), nil
-	case misc.RealmManagement:
+	case astarteservices.RealmManagement:
 		return hasAuth(claims.RealmManagement), nil
-	case misc.Housekeeping:
+	case astarteservices.Housekeeping:
 		return hasAuth(claims.Housekeeping), nil
-	case misc.Pairing:
+	case astarteservices.Pairing:
 		return hasAuth(claims.Pairing), nil
-	case misc.Channels:
+	case astarteservices.Channels:
 		return hasAuth(claims.Channels), nil
-	case misc.Flow:
+	case astarteservices.Flow:
 		return hasAuth(claims.Flow), nil
 	default:
 		return false, fmt.Errorf("unknown Astarte service %s", service.String())

--- a/auth/token.go
+++ b/auth/token.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package misc
+package auth
 
 import (
 	"crypto/ecdsa"
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/astarte-platform/astarte-go/misc"
 	jwt "github.com/cristalhq/jwt/v3"
 )
 
@@ -55,7 +56,7 @@ func (u *AstarteClaims) MarshalBinary() ([]byte, error) {
 // GenerateAstarteJWTFromKeyFile generates an Astarte Token for a specific API out of a Private Key File.
 // servicesAndClaims specifies which services with which claims the token will be authorized to access. Leaving
 // a claim empty will imply `.*::.*`, aka access to the entirety of the service's API tree
-func GenerateAstarteJWTFromKeyFile(privateKeyFile string, servicesAndClaims map[AstarteService][]string,
+func GenerateAstarteJWTFromKeyFile(privateKeyFile string, servicesAndClaims map[misc.AstarteService][]string,
 	ttlSeconds int64) (jwtString string, err error) {
 	keyPEM, err := ioutil.ReadFile(privateKeyFile)
 	if err != nil {
@@ -107,7 +108,7 @@ func ParsePrivateKeyFromPEM(key []byte) (interface{}, error) {
 // GenerateAstarteJWTFromPEMKey generates an Astarte Token for a specific API out of a Private Key PEM bytearray.
 // servicesAndClaims specifies which services with which claims the token will be authorized to access. Leaving
 // a claim empty will imply `.*::.*`, aka access to the entirety of the service's API tree
-func GenerateAstarteJWTFromPEMKey(privateKeyPEM []byte, servicesAndClaims map[AstarteService][]string,
+func GenerateAstarteJWTFromPEMKey(privateKeyPEM []byte, servicesAndClaims map[misc.AstarteService][]string,
 	ttlSeconds int64) (jwtString string, err error) {
 	key, err := ParsePrivateKeyFromPEM(privateKeyPEM)
 	if err != nil {
@@ -127,7 +128,7 @@ func GenerateAstarteJWTFromPEMKey(privateKeyPEM []byte, servicesAndClaims map[As
 	for svc, c := range servicesAndClaims {
 		if len(c) == 0 {
 			switch svc {
-			case Channels:
+			case misc.Channels:
 				c = []string{"JOIN::.*", "WATCH::.*"}
 			default:
 				c = []string{".*::.*"}
@@ -135,17 +136,17 @@ func GenerateAstarteJWTFromPEMKey(privateKeyPEM []byte, servicesAndClaims map[As
 		}
 
 		switch svc {
-		case AppEngine:
+		case misc.AppEngine:
 			claims.AppEngineAPI = c
-		case Channels:
+		case misc.Channels:
 			claims.Channels = c
-		case Flow:
+		case misc.Flow:
 			claims.Flow = c
-		case Housekeeping:
+		case misc.Housekeeping:
 			claims.Housekeeping = c
-		case Pairing:
+		case misc.Pairing:
 			claims.Pairing = c
-		case RealmManagement:
+		case misc.RealmManagement:
 			claims.RealmManagement = c
 		}
 	}
@@ -181,23 +182,23 @@ func GetJWTAstarteClaims(rawToken string) (AstarteClaims, error) {
 }
 
 // IsJWTAstarteClaimValidForService verifies that an Astarte Token has access to a given Astarte service.
-func IsJWTAstarteClaimValidForService(token string, service AstarteService) (bool, error) {
+func IsJWTAstarteClaimValidForService(token string, service misc.AstarteService) (bool, error) {
 	claims, err := GetJWTAstarteClaims(token)
 	if err != nil {
 		return false, err
 	}
 	switch service {
-	case AppEngine:
+	case misc.AppEngine:
 		return hasAuth(claims.AppEngineAPI), nil
-	case RealmManagement:
+	case misc.RealmManagement:
 		return hasAuth(claims.RealmManagement), nil
-	case Housekeeping:
+	case misc.Housekeeping:
 		return hasAuth(claims.Housekeeping), nil
-	case Pairing:
+	case misc.Pairing:
 		return hasAuth(claims.Pairing), nil
-	case Channels:
+	case misc.Channels:
 		return hasAuth(claims.Channels), nil
-	case Flow:
+	case misc.Flow:
 		return hasAuth(claims.Flow), nil
 	default:
 		return false, fmt.Errorf("unknown Astarte service %s", service.String())

--- a/client/appengine_groups.go
+++ b/client/appengine_groups.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/astarte-platform/astarte-go/misc"
+	"github.com/astarte-platform/astarte-go/deviceid"
 	"moul.io/http2curl"
 )
 
@@ -72,7 +72,7 @@ type CreateGroupRequest struct {
 // Only valid Astarte device IDs can be used when adding devices to a group.
 func (c *Client) CreateGroup(realm, groupName string, deviceIDList []string) (AstarteRequest, error) {
 	for _, deviceID := range deviceIDList {
-		if !misc.IsValidAstarteDeviceID(deviceID) {
+		if !deviceid.IsValid(deviceID) {
 			return Empty{}, ErrInvalidDeviceID(deviceID)
 		}
 	}
@@ -123,7 +123,7 @@ type AddDeviceToGroupRequest struct {
 // AddDeviceToGroup builds a request to add a device to a group.
 // Only valid Astarte device IDs can be used when adding a device to a group.
 func (c *Client) AddDeviceToGroup(realm, groupName, deviceID string) (AstarteRequest, error) {
-	if !misc.IsValidAstarteDeviceID(deviceID) {
+	if !deviceid.IsValid(deviceID) {
 		return Empty{}, ErrInvalidDeviceID(deviceID)
 	}
 
@@ -159,7 +159,7 @@ type RemoveDeviceFromGroupRequest struct {
 // RemoveDeviceFromGroup builds a request to removes a device from the group.
 // Only valid Astarte device IDs can be used when removing a device from a group.
 func (c *Client) RemoveDeviceFromGroup(realm, groupName, deviceID string) (AstarteRequest, error) {
-	if !misc.IsValidAstarteDeviceID(deviceID) {
+	if !deviceid.IsValid(deviceID) {
 		return Empty{}, ErrInvalidDeviceID(deviceID)
 	}
 

--- a/client/appengine_internal.go
+++ b/client/appengine_internal.go
@@ -17,7 +17,7 @@ package client
 import (
 	"fmt"
 
-	"github.com/astarte-platform/astarte-go/misc"
+	"github.com/astarte-platform/astarte-go/deviceid"
 )
 
 // resolveDeviceIdentifierType maps a deviceIdentifier and DeviceIdentifierType to a resolved
@@ -27,7 +27,7 @@ import (
 func resolveDeviceIdentifierType(deviceIdentifier string, deviceIdentifierType DeviceIdentifierType) DeviceIdentifierType {
 	switch deviceIdentifierType {
 	case AutodiscoverDeviceIdentifier:
-		if misc.IsValidAstarteDeviceID(deviceIdentifier) {
+		if deviceid.IsValid(deviceIdentifier) {
 			return AstarteDeviceID
 		}
 		return AstarteDeviceAlias

--- a/client/client.go
+++ b/client/client.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/astarte-platform/astarte-go/astarteservices"
 	"github.com/astarte-platform/astarte-go/auth"
 )
 

--- a/client/client.go
+++ b/client/client.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/astarte-platform/astarte-go/misc"
+	"github.com/astarte-platform/astarte-go/auth"
 )
 
 const defaultJWTExpiry = 300
@@ -251,17 +251,17 @@ func setDefaults(c *Client) *Client {
 
 func (c *Client) getJWT() string {
 	// Add all types
-	servicesAndClaims := map[misc.AstarteService][]string{
-		misc.AppEngine:       {},
-		misc.Channels:        {},
-		misc.Flow:            {},
-		misc.Housekeeping:    {},
-		misc.Pairing:         {},
-		misc.RealmManagement: {},
+	servicesAndClaims := map[astarteservices.AstarteService][]string{
+		astarteservices.AppEngine:       {},
+		astarteservices.Channels:        {},
+		astarteservices.Flow:            {},
+		astarteservices.Housekeeping:    {},
+		astarteservices.Pairing:         {},
+		astarteservices.RealmManagement: {},
 	}
 	if c.token == "" {
 		// if we're here, we can safely assume that the key was OK
-		token, _ := misc.GenerateAstarteJWTFromPEMKey(c.privateKey, servicesAndClaims, int64(c.expiry))
+		token, _ := auth.GenerateAstarteJWTFromPEMKey(c.privateKey, servicesAndClaims, int64(c.expiry))
 		return token
 	}
 	return c.token

--- a/deviceid/deviceid.go
+++ b/deviceid/deviceid.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package misc
+package deviceid
 
 import (
 	"encoding/base64"
@@ -20,8 +20,8 @@ import (
 	"github.com/google/uuid"
 )
 
-// IsValidAstarteDeviceID returns whether the provided Device ID is a valid Astarte Device ID or not.
-func IsValidAstarteDeviceID(deviceID string) bool {
+// IsValid returns whether the provided Device ID is a valid Astarte Device ID or not.
+func IsValid(deviceID string) bool {
 	decoded, err := base64.RawURLEncoding.DecodeString(deviceID)
 	if err != nil {
 		return false
@@ -35,9 +35,9 @@ func IsValidAstarteDeviceID(deviceID string) bool {
 	return true
 }
 
-// GenerateRandomAstarteDeviceID returns a new Astarte Device ID on a fully Random basis.
+// GenerateRandom returns a new Astarte Device ID on a fully Random basis.
 // Do not use in production environments.
-func GenerateRandomAstarteDeviceID() (string, error) {
+func GenerateRandom() (string, error) {
 	randomUUID, err := uuid.NewRandom()
 	if err != nil {
 		return "", err
@@ -50,10 +50,10 @@ func GenerateRandomAstarteDeviceID() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(deviceID), nil
 }
 
-// GenerateAstarteDeviceID returns an Astarte Device ID generated from a namespaced arbitrary payload.
+// Generate returns an Astarte Device ID generated from a namespaced arbitrary payload.
 // It is guaranteed to be always the same for the same namespace and payload.
 // This is the go-to function to generate Astarte device IDs.
-func GenerateAstarteDeviceID(uuidNamespace string, payloadData []byte) (string, error) {
+func Generate(uuidNamespace string, payloadData []byte) (string, error) {
 	encodedUUIDNamespace, err := uuid.Parse(uuidNamespace)
 	if err != nil {
 		return "", err
@@ -69,17 +69,10 @@ func GenerateAstarteDeviceID(uuidNamespace string, payloadData []byte) (string, 
 	return base64.RawURLEncoding.EncodeToString(deviceID), nil
 }
 
-// Deprecated: This function will be removed in next releases. Use `GenerateAstarteDeviceID`.
-// GetNamespacedAstarteDeviceID returns an Astarte Device ID generated from a namespaced arbitrary payload.
-// It is guaranteed to be always the same for the same namespace and payload
-func GetNamespacedAstarteDeviceID(uuidNamespace string, payloadData []byte) (string, error) {
-	return GenerateAstarteDeviceID(uuidNamespace, payloadData)
-}
-
-// DeviceIDToUUID converts a Device ID from the standard Astarte representation (Base 64 Url Encoded) to
+// ToUUID converts a Device ID from the standard Astarte representation (Base 64 Url Encoded) to
 // UUID string representation. This is useful to interact directly with Cassandra, that uses that
 // representation to store Device IDs.
-func DeviceIDToUUID(deviceID string) (string, error) {
+func ToUUID(deviceID string) (string, error) {
 	bytes, err := base64.RawURLEncoding.DecodeString(deviceID)
 	if err != nil {
 		return "", err
@@ -92,9 +85,9 @@ func DeviceIDToUUID(deviceID string) (string, error) {
 	return deviceUUID.String(), nil
 }
 
-// UUIDToDeviceID converts a UUID string to a Device ID in the standard Astarte representation (Base
+// FromUUID converts a UUID string to a Device ID in the standard Astarte representation (Base
 // 64 Url Encoded)
-func UUIDToDeviceID(deviceUUIDString string) (string, error) {
+func FromUUID(deviceUUIDString string) (string, error) {
 	deviceUUID, err := uuid.Parse(deviceUUIDString)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Split the package in three, more coherent parts:
 - `auth` (JWT and such);
 - `deviceid` (id generation and validation);
 - `astarteservices` (useful constants to represent Astarte services).
 
 Close #31.