### PR TITLE
Fix Raw for responses with a paginator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - BREAKING: Remove the 0.90.1 Astarte client API and introduce a clean, idiomatic API.
   See [#33](https://github.com/astarte-platform/astarte-go/issues/33).
 
+### Fixed
+- `Raw` properly updates the paginator's state when retrieving paginated data.
+
 ## [0.90.1] - 2021-03-03
 ### Changed
 - Update dependencies

--- a/client/data.go
+++ b/client/data.go
@@ -26,6 +26,7 @@ type AstarteResponse interface {
 	Parse() (any, error)
 	// Raw allows to supply a custom http Response handling function for the Astarte
 	// response. The function does not need to close the response body.
+	// Raw simply returns the value returned by the handling function.
 	Raw(func(*http.Response) any) any
 }
 


### PR DESCRIPTION
When Raw is called for responses whose structure include a paginator, the state of that paginator must be updated. To do so, compute the page state without losing the content of the response's body.