### PR TITLE
Fix: allow the creation of a realm when using network topology strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.91.1] - Unreleased
+### Fixed
+- Allow the creation of realms when using network topology strategy. Fixes a regression introduced
+  in v0.91.0.
+
 ## [0.91.0] - 2023-05-29
 ### Changed
 - Replace device `metadata` with `attributes`.

--- a/client/housekeeping.go
+++ b/client/housekeeping.go
@@ -169,8 +169,7 @@ func WithReplicationFactor(replicationFactor int) realmOption {
 func WithDatacenterReplicationFactors(datacenterReplicationFactors map[string]int) realmOption {
 	return func(req *newRealmRequestBuilder) {
 		req.DatacenterReplicationFactors = datacenterReplicationFactors
-		//nolint:gosimple
-		req.ReplicationClass = fmt.Sprintf("\"NetworkTopologyStrategy\"")
+		req.ReplicationClass = fmt.Sprintf("NetworkTopologyStrategy")
 	}
 }
 


### PR DESCRIPTION
An extra layer of quotes caused a malformed request, leading to the impossibility of creating a realm when a network topology strategy is set. Thus, remove the extra quotes.