### PR TITLE
Fix simple strategy option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.91.1] - Unreleased
 ### Fixed
-- Allow the creation of realms when using network topology strategy. Fixes a regression introduced
-  in v0.91.0.
+- Allow the creation of realms when explicitly setting a replication class. Fixes a regression
+  introduced in v0.91.0.
 
 ## [0.91.0] - 2023-05-29
 ### Changed

--- a/client/housekeeping.go
+++ b/client/housekeeping.go
@@ -160,7 +160,7 @@ func WithReplicationFactor(replicationFactor int) realmOption {
 	return func(req *newRealmRequestBuilder) {
 		req.ReplicationFactor = replicationFactor
 		//nolint:gosimple
-		req.ReplicationClass = fmt.Sprintf("\"SimpleStrategy\"")
+		req.ReplicationClass = fmt.Sprintf("SimpleStrategy")
 	}
 }
 


### PR DESCRIPTION
An extra layer of quotes caused a malformed request, leading to the impossibility of creating a realm when a simple strategy is set. Thus, remove the extra quotes.