### PR TITLE
Trigger validation

### DIFF
--- a/triggers/astarte_trigger.go
+++ b/triggers/astarte_trigger.go
@@ -1,0 +1,386 @@
+// Copyright © 2020-2023 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package triggers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+)
+
+type AstarteTriggerMatchOperator string
+
+const (
+	All    AstarteTriggerMatchOperator = "*"
+	Equal  AstarteTriggerMatchOperator = "=="
+	Differ AstarteTriggerMatchOperator = "!="
+
+	Bigger       AstarteTriggerMatchOperator = ">"
+	BiggerEqual  AstarteTriggerMatchOperator = ">="
+	Smaller      AstarteTriggerMatchOperator = "<"
+	SmallerEqual AstarteTriggerMatchOperator = "<="
+	Contains     AstarteTriggerMatchOperator = "contains"
+	NotContains  AstarteTriggerMatchOperator = "not_contains"
+)
+
+// IsValid returns an error if AstarteTriggerType does not represent a valid AstarteTriggerMatchOperator
+func (t AstarteTriggerMatchOperator) IsValid() error {
+	switch t {
+	case All, Equal, Differ, Bigger, BiggerEqual, Smaller, SmallerEqual, Contains, NotContains:
+		return nil
+	}
+	return errors.New("invalid Astarte Trigger type")
+}
+
+// UnmarshalJSON unmashals a quoted json string to the enum value
+func (t *AstarteTriggerMatchOperator) UnmarshalJSON(b []byte) error {
+	var j string
+	if err := json.Unmarshal(b, &j); err != nil {
+		return err
+	}
+
+	*t = AstarteTriggerMatchOperator(j)
+	if err := t.IsValid(); err != nil {
+		return fmt.Errorf("'%v' is not a valid AstarteTriggerMatchOperator", j)
+	}
+	return nil
+}
+
+type AstarteTriggerOn string
+
+const (
+	DeviceConnected    AstarteTriggerOn = "device_connected"
+	DeviceDisconnected AstarteTriggerOn = "device_disconnected"
+	DeviceError        AstarteTriggerOn = "device_error"
+
+	IncomingData       AstarteTriggerOn = "incoming_data"
+	ValueStored        AstarteTriggerOn = "value_stored"
+	ValueChange        AstarteTriggerOn = "value_change"
+	ValueChangeApplied AstarteTriggerOn = "value_change_applied"
+	PathCreated        AstarteTriggerOn = "path_created"
+	PathRemoved        AstarteTriggerOn = "path_removed"
+)
+
+// IsValid returns an error if AstarteTriggerType does not represent a valid AstarteTriggerOn
+func (t AstarteTriggerOn) IsValid() error {
+	switch t {
+	case DeviceConnected, DeviceDisconnected, DeviceError:
+		return nil
+	case IncomingData, ValueStored, ValueChange, ValueChangeApplied, PathCreated, PathRemoved:
+		return nil
+	}
+	return errors.New("invalid Astarte Trigger type")
+}
+
+// UnmarshalJSON unmashals a quoted json string to the enum value
+func (t *AstarteTriggerOn) UnmarshalJSON(b []byte) error {
+	var j string
+	if err := json.Unmarshal(b, &j); err != nil {
+		return err
+	}
+
+	*t = AstarteTriggerOn(j)
+	if err := t.IsValid(); err != nil {
+		return fmt.Errorf("'%v' is not a valid AstarteTriggerOn", j)
+	}
+	return nil
+}
+
+// AstarteTriggerType represents which kind of Astarte trigger the object represents
+type AstarteTriggerType string
+
+const (
+	// DataType represents a data trigger
+	DataType AstarteTriggerType = "data_trigger"
+	// DataType represents a device trigger
+	DeviceType AstarteTriggerType = "device_trigger"
+)
+
+// IsValid returns an error if AstarteTriggerType does not represent a valid Astarte Trigger Type
+func (t AstarteTriggerType) IsValid() error {
+	switch t {
+	case DataType, DeviceType:
+		return nil
+	}
+	return errors.New("invalid Astarte Trigger type")
+}
+
+// UnmarshalJSON unmashals a quoted json string to the enum value
+func (t *AstarteTriggerType) UnmarshalJSON(b []byte) error {
+	var j string
+	if err := json.Unmarshal(b, &j); err != nil {
+		return err
+	}
+
+	*t = AstarteTriggerType(j)
+	if err := t.IsValid(); err != nil {
+		return fmt.Errorf("'%v' is not a valid Astarte Trigger Type", j)
+	}
+	return nil
+}
+
+// AstarteHTTPMethod represents the kind of http method used
+type AstarteHTTPMethod string
+
+const (
+	PostMethod   AstarteHTTPMethod = "post"
+	GetMethod    AstarteHTTPMethod = "get"
+	PutMethod    AstarteHTTPMethod = "put"
+	PatchMethod  AstarteHTTPMethod = "patch"
+	DeleteMethod AstarteHTTPMethod = "delete"
+)
+
+// IsValid returns an error if AstarteHTTPMethod does not represent a valid AstarteHTTPMethod
+func (o AstarteHTTPMethod) IsValid() error {
+	switch o {
+	case PostMethod, GetMethod, PutMethod, PatchMethod, DeleteMethod:
+		return nil
+	}
+	return errors.New("invalid AstarteHTTPMethod")
+}
+
+// UnmarshalJSON unmashals a quoted json string to the enum value
+func (o *AstarteHTTPMethod) UnmarshalJSON(b []byte) error {
+	var j string
+	if err := json.Unmarshal(b, &j); err != nil {
+		return err
+	}
+
+	*o = AstarteHTTPMethod(j)
+	if err := o.IsValid(); err != nil {
+		return fmt.Errorf("'%v' is not a valid AstarteHTTPMethod", j)
+	}
+	return nil
+}
+
+type AstarteTriggerAction struct {
+	HTTPUrl         string            `json:"http_url"`
+	HTTPMethod      AstarteHTTPMethod `json:"http_method"`
+	HTTPHeaders     string            `json:"http_static_headers"`
+	IgnoreSslErrors bool              `default:"false"`
+}
+type AstarteSimpleTrigger struct {
+	Type               AstarteTriggerType          `json:"type"`
+	On                 AstarteTriggerOn            `json:"on"`
+	DeviceID           string                      `json:"device_id,omitempty"`
+	GroupName          string                      `json:"group_name,omitempty"`
+	InterfaceName      string                      `json:"interface_name,omitempty"`
+	InterfaceMajor     json.Number                 `json:"interface_major,omitempty"`
+	MatchPath          string                      `json:"match_path,omitempty"`
+	ValueMatchOperator AstarteTriggerMatchOperator `json:"value_match_operator"`
+	KnownValue         *json.Number                `json:"known_value,omitempty"`
+}
+
+// AstarteTrigger represents an Astarte Trigger
+type AstarteTrigger struct {
+	Name           string                 `json:"name"`
+	Action         AstarteTriggerAction   `json:"action"`
+	SimpleTriggers []AstarteSimpleTrigger `json:"simple_triggers"`
+}
+
+// requiredAstarteTrigger is an helper struct used for validating required fields when unmarshalling an
+// astarte trigger. Its fields are defined as pointers so that it is possible determining if any field is
+// present and valid.
+type requiredAstarteTrigger struct {
+	Name           *string                        `json:"name"`
+	Action         *requiredAstarteTriggerAction  `json:"action"`
+	SimpleTriggers []requiredAstarteSimpleTrigger `json:"simple_triggers"`
+}
+type requiredAstarteTriggerAction struct {
+	HTTPUrl    *string            `json:"http_url"`
+	HTTPMethod *AstarteHTTPMethod `json:"http_method"`
+}
+
+type requiredAstarteSimpleTrigger struct {
+	Type      *AstarteTriggerType `json:"type"`
+	On        *AstarteTriggerOn   `json:"on"`
+	DeviceID  *string             `json:"device_id,omitempty"`
+	GroupName *string             `json:"group_name,omitempty"`
+
+	InterfaceName      *string                      `json:"interface_name,omitempty"`
+	InterfaceMajor     *json.Number                 `json:"interface_major,omitempty"`
+	MatchPath          *string                      `json:"match_path,omitempty"`
+	ValueMatchOperator *AstarteTriggerMatchOperator `json:"value_match_operator"`
+	KnownValue         *json.Number                 `json:"known_value,omitempty"`
+}
+
+// ensureRequiredFields ensures that any required fields within an AstarteTrigger is present and valid. It is
+// employed in place of the UnmarshalJSON interface to avoid infinite loops when unmarshalling an AstarteTrigger
+//
+//nolint:all
+func (r *requiredAstarteTrigger) ensureRequiredFields(b []byte) error {
+
+	required := requiredAstarteTrigger{}
+	if err := json.Unmarshal(b, &required); err != nil {
+		return err
+	}
+	if required.Name == nil || (required.Name != nil && *required.Name == "") {
+		return errors.New("Invalid trigger: name must be set")
+	}
+	if required.Action == nil {
+		return errors.New("Invalid trigger: action must be set")
+	}
+	if required.Action.HTTPUrl == nil || required.Action.HTTPMethod == nil {
+		return errors.New("Invalid trigger: action must have at least an url and a method set")
+	}
+	if required.Action.HTTPMethod.IsValid() != nil {
+		return errors.New("Invalid trigger: invalid method for action")
+	}
+
+	if len(required.SimpleTriggers) == 0 {
+		return errors.New("Invalid trigger: no triggers are present")
+	}
+	if len(required.SimpleTriggers) > 1 {
+		return errors.New("Invalid trigger: usage of more than one trigger is currently unsupported")
+	}
+
+	for _, trigger := range required.SimpleTriggers {
+		err2 := simpleTriggerCheck(&trigger)
+		if err2 != nil {
+			return err2
+		}
+	}
+	return nil
+}
+
+//nolint:all
+func simpleTriggerCheck(trigger *requiredAstarteSimpleTrigger) error {
+	if trigger.Type == nil || trigger.On == nil {
+		return errors.New("Invalid trigger condition: Type and On must be set")
+	}
+
+	if *trigger.Type != "data_trigger" {
+
+		if *trigger.On != "device_connected" && *trigger.On != "device_disconnected" &&
+			*trigger.On != "device_error" {
+			return fmt.Errorf("Invalid trigger condition: invalid On value '%v'", *trigger.On)
+		}
+
+		if trigger.DeviceID == nil && trigger.GroupName == nil {
+			return errors.New("Invalid trigger condition: DeviceID or GroupName must be set")
+		}
+		if trigger.DeviceID != nil && trigger.GroupName != nil {
+			return errors.New("Invalid trigger condition: DeviceID or GroupName cannot both be set ")
+		}
+
+		if trigger.InterfaceName != nil ||
+			trigger.InterfaceMajor != nil ||
+			trigger.MatchPath != nil ||
+			trigger.ValueMatchOperator != nil ||
+			trigger.KnownValue != nil {
+			return errors.New("Invalid trigger: cannot set properties for data trigger on a device trigger")
+		}
+
+	} else {
+		if *trigger.On != "incoming_data" &&
+			*trigger.On != "value_stored" &&
+			*trigger.On != "value_change" &&
+			*trigger.On != "value_change_applied" &&
+			*trigger.On != "path_created" &&
+			*trigger.On != "path_removed" {
+			return fmt.Errorf("Invalid trigger condition: invalid On value '%v'", *trigger.On)
+		}
+		if trigger.DeviceID != nil || trigger.GroupName != nil {
+			return errors.New("Invalid trigger condition: DeviceID or GroupName cannot be set ")
+		}
+		if trigger.InterfaceName == nil {
+			return errors.New("Invalid data trigger: interface not set, use * to catch all")
+		}
+		if trigger.InterfaceMajor == nil && *trigger.InterfaceName != "*" {
+			return errors.New("Invalid data trigger:  InterfaceMajor must be set")
+		}
+		if trigger.MatchPath == nil {
+			return errors.New("Invalid data trigger: MatchPath not set")
+		}
+		if trigger.ValueMatchOperator == nil {
+			return errors.New("Invalid data trigger: ValueMatchOperator not set")
+		}
+		if trigger.KnownValue == nil {
+			return errors.New("Invalid data trigger: KnownValue not set")
+		}
+
+	}
+	return nil
+}
+
+// triggerProvider is the object that holds a trigger
+type triggerProvider interface {
+	[]byte | string
+}
+
+// ParseTriggerFrom is a convenience function to call ParseTrigger with an input.
+// The input hcan be either a string, tat is interpreted as a file path, or a byteslice.
+func ParseTriggerFrom[T triggerProvider](provider T) (AstarteTrigger, error) {
+	switch p := any(provider).(type) {
+	case string:
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return AstarteTrigger{}, err
+		}
+		return ParseTrigger(b)
+	case []byte:
+		return ParseTrigger(p)
+	default:
+		return AstarteTrigger{}, errors.New("Provided value cannot be used as an Astarte Trigger")
+	}
+}
+
+// ParseTrigger parses a trigger from a JSON string and returns an AstarteTrigger object when successful.
+// Please use this method rather than calling json.Unmarshal on a Trigger, as this will set any missing field
+// to the correct, expected default value
+func ParseTrigger(triggerContent []byte) (AstarteTrigger, error) {
+	astarteTrigger := AstarteTrigger{}
+	required := requiredAstarteTrigger{}
+
+	if err := required.ensureRequiredFields(triggerContent); err != nil {
+		return astarteTrigger, err
+	}
+
+	if err := json.Unmarshal(triggerContent, &astarteTrigger); err != nil {
+		return astarteTrigger, err
+	}
+
+	return EnsureTriggerDefaults(astarteTrigger), nil
+}
+
+// EnsureTriggerDefaults makes sure a JSON-parsed Trigger will have all defaults set. Usually, you should never
+// call this method - ParseTrigger does the right thing. It might become useful in case you're dealing with a
+// json.Decoder to parse Trigger information
+func EnsureTriggerDefaults(astarteTrigger AstarteTrigger) AstarteTrigger {
+
+	// Ensure we have all defaults set
+	if err := astarteTrigger.Action.HTTPMethod.IsValid(); err != nil {
+		astarteTrigger.Action.HTTPMethod = GetMethod
+	}
+
+	subsMapping := []AstarteSimpleTrigger{}
+	for _, v := range astarteTrigger.SimpleTriggers {
+
+		if err := v.Type.IsValid(); err != nil {
+			v.Type = DataType
+		}
+		if err := v.On.IsValid(); err != nil {
+			v.On = DeviceConnected
+		}
+		if err := v.ValueMatchOperator.IsValid(); err != nil {
+			v.ValueMatchOperator = All
+		}
+		subsMapping = append(subsMapping, v)
+	}
+	astarteTrigger.SimpleTriggers = subsMapping
+
+	return astarteTrigger
+}

--- a/triggers/astarte_trigger_test.go
+++ b/triggers/astarte_trigger_test.go
@@ -1,0 +1,679 @@
+// Copyright © 2020-2023 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package triggers
+
+import (
+	_ "encoding/json"
+	"testing"
+)
+
+func TestMissingDataFromTriggerAction(t *testing.T) {
+
+	MissingTriggerName := `
+	{
+		"action": {
+		  "http_url": "https://example.com/my_hook",
+		  "http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "org.astarte-platform.genericsensors.Values",
+			"interface_major": 0,
+			"match_path": "/streamTest/value",
+			"value_match_operator": ">",
+			"known_value": 0.4
+		  }
+		]
+	  }`
+
+	_, err := ParseTriggerFrom([]byte(MissingTriggerName))
+	if err == nil {
+		t.Error("This trigger should have failed validation! Missing name")
+	}
+
+	EmptyTriggerName := `
+	{
+		"name": "",
+		"action": {
+		  "http_url": "https://example.com/my_hook",
+		  "http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "org.astarte-platform.genericsensors.Values",
+			"interface_major": 0,
+			"match_path": "/streamTest/value",
+			"value_match_operator": ">",
+			"known_value": 0.4
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(EmptyTriggerName))
+	if err == nil {
+		t.Error("This trigger should have failed validation! Empty name")
+	}
+
+	MissinigURL := `
+	{
+		"name": "test",
+		"action": {
+		  "http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "org.astarte-platform.genericsensors.Values",
+			"interface_major": 0,
+			"match_path": "/streamTest/value",
+			"value_match_operator": ">",
+			"known_value": 0.4
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(MissinigURL))
+	if err == nil {
+		t.Error("This trigger should have failed validation! Missing URL")
+	}
+
+	MissinigMethod := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "org.astarte-platform.genericsensors.Values",
+			"interface_major": 0,
+			"match_path": "/streamTest/value",
+			"value_match_operator": ">",
+			"known_value": 0.4
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(MissinigMethod))
+	if err == nil {
+		t.Error("This trigger should have failed validation! Missing http method")
+	}
+
+	DeviceTriggerInvalidHTTP := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "posta"
+		},
+		"simple_triggers": [
+		  {
+			"type": "invalid_trigger",
+			"on": "incoming_data",
+			"interface_name": "*",
+			"match_path":"/*",
+			"value_match_operator":"==",
+			"known_value":"3"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerInvalidHTTP))
+	if err == nil {
+		t.Error("This trigger should have Failed! invalid http method")
+	}
+}
+
+func TestInvalidTriggerData(t *testing.T) {
+	DeviceTriggerInvalidMatchOperator := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "*",
+			"match_path":"/*",
+			"value_match_operator":"",
+			"known_value":"3"
+		  }
+		]
+	  }`
+
+	_, err := ParseTriggerFrom([]byte(DeviceTriggerInvalidMatchOperator))
+	if err == nil {
+		t.Error("This trigger should have Failed! invalid json match operator")
+	}
+
+	DeviceTriggerInvalidType := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "invalid_trigger",
+			"on": "incoming_data",
+			"interface_name": "*",
+			"match_path":"/*",
+			"value_match_operator":"==",
+			"known_value":"3"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerInvalidType))
+	if err == nil {
+		t.Error("This trigger should have Failed! invalid trigger type")
+	}
+
+	DeviceTriggerInvalidOn := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "device_trigger",
+			"on": "AAAAAAAAAAAAAA",
+			"device_id": "45336"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerInvalidOn))
+	if err == nil {
+		t.Error("This trigger should have failed validation! invalid 'on' condition")
+	}
+
+	DeviceTriggerIncorrectOn := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "device_trigger",
+			"on": "incoming_data",
+			"device_id": "45336"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerIncorrectOn))
+	if err == nil {
+		t.Error("This trigger should have failed validation! invalid 'on' condition")
+	}
+
+	DeviceTriggerMismatchOn := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerMismatchOn))
+	if err == nil {
+		t.Error("This trigger should have failed validation! mismatched 'on' condition for trigger type")
+	}
+
+}
+func TestInvalidTriggerInterface(t *testing.T) {
+
+	DeviceTriggerInterfaceNull := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data"
+		  }
+		]
+	  }`
+
+	_, err := ParseTriggerFrom([]byte(DeviceTriggerInterfaceNull))
+	if err == nil {
+		t.Error("This trigger should have failed validation! no interfaces specified")
+	}
+
+	DeviceTriggerMajorNull := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "AAA"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerMajorNull))
+	if err == nil {
+		t.Error("This trigger should have failed validation! no interface major specified")
+	}
+
+	DeviceTriggerMajorNotNull := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "AAA",
+			"interface_major": "2",
+			"match_path":"/*",
+			"value_match_operator":"==",
+			"known_value":"3"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerMajorNotNull))
+	if err != nil {
+		t.Error("This trigger should have passed!")
+	}
+
+	DeviceTriggerMajorNullable := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "*",
+			"match_path":"/*",
+			"value_match_operator":"==",
+			"known_value":"3"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerMajorNullable))
+	if err != nil {
+		t.Error("This trigger should have passed!")
+	}
+
+}
+
+func TestInvalidTriggerGenericErrors(t *testing.T) {
+
+	DeviceTriggerGroupAndID := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "device_trigger",
+			"on": "device_connected",
+			"device_id": "45336",
+			"group_name": "sdgfsd"
+		  }
+		]
+	  }`
+
+	_, err := ParseTriggerFrom([]byte(DeviceTriggerGroupAndID))
+	if err == nil {
+		t.Error("This trigger should have failed validation! cannot use device_id and group_name")
+	}
+
+	DeviceTriggerNoAction := `
+	{
+		"name": "test",
+		"action":"",
+		"simple_triggers": [
+		  {
+			"type": "invalid_trigger",
+			"on": "incoming_data",
+			"interface_name": "*",
+			"match_path":"/*",
+			"value_match_operator":"==",
+			"known_value":"3"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerNoAction))
+	if err == nil {
+		t.Error("This trigger should have Failed! required action")
+
+	}
+
+	DeviceTriggerNoTriggers := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": []
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerNoTriggers))
+	if err == nil {
+		t.Error("This trigger should have Failed! one trigger definition is required")
+	}
+
+	DeviceTriggerTooManyTriggers := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "device_trigger",
+			"on": "incoming_data",
+			"interface_name": "*",
+			"match_path":"/*",
+			"value_match_operator":"==",
+			"known_value":"3"
+		  },
+		  {
+			"type": "device_trigger",
+			"on": "incoming_data",
+			"interface_name": "*",
+			"match_path":"/*",
+			"value_match_operator":"==",
+			"known_value":"3"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerTooManyTriggers))
+	if err == nil {
+		t.Error("This trigger should have Failed! Too many triggers defined")
+	}
+
+	DeviceTriggerTypeNotSet := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"on": "incoming_data",
+			"interface_name": "*",
+			"match_path":"/*",
+			"value_match_operator":"==",
+			"known_value":"3"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerTypeNotSet))
+	if err == nil {
+		t.Error("This trigger should have Failed! type not set for trigger")
+	}
+
+	DeviceTriggerNoDeviceOrGroup := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "device_trigger",
+			"on": "device_connected"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerNoDeviceOrGroup))
+	if err == nil {
+		t.Error("This trigger should have Failed! device_id or group should be set")
+	}
+
+	DeviceTriggerInvalidDevice := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "device_trigger",
+			"on": "device_connected",
+			"device_id": "dsagfsda",
+			"interface_name": "*"
+
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerInvalidDevice))
+	if err == nil {
+		t.Error("This trigger should have Failed! invalid data for device")
+	}
+
+	DeviceTriggerInvalidDataTrigger := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "device_disconnected"
+
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerInvalidDataTrigger))
+	if err == nil {
+		t.Error("This trigger should have Failed! invalid data for trigger type data")
+	}
+
+	DeviceTriggerInvalidDataTrigger2 := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"device_id":"34523"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerInvalidDataTrigger2))
+	if err == nil {
+		t.Error("This trigger should have Failed! invalid data for trigger type data")
+	}
+
+	DeviceTriggerInvalidDataTrigger3 := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "*"
+
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerInvalidDataTrigger3))
+	if err == nil {
+		t.Error("This trigger should have Failed! invalid data for trigger type data")
+	}
+
+	DeviceTriggerInvalidDataTrigger4 := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "*",
+			"match_path":"/*"
+
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerInvalidDataTrigger4))
+	if err == nil {
+		t.Error("This trigger should have Failed! invalid data for trigger type data")
+	}
+
+	DeviceTriggerInvalidDataTrigger5 := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "*",
+			"match_path":"/*",
+			"value_match_operator":"=="
+
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerInvalidDataTrigger5))
+	if err == nil {
+		t.Error("This trigger should have Failed!invalid data for trigger type data")
+	}
+
+}
+
+//nolint:all
+func TestParsing(t *testing.T) {
+
+	DataTriggerOk := `
+	{
+		"name": "example_trigger",
+		"action": {
+		  "http_url": "https://example.com/my_hook",
+		  "http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "org.astarte-platform.genericsensors.Values",
+			"interface_major": 0,
+			"match_path": "/streamTest/value",
+			"value_match_operator": ">",
+			"known_value": 0.4
+		  }
+		]
+	  }`
+
+	i, err := ParseTriggerFrom([]byte(DataTriggerOk))
+	if err != nil {
+		t.Error(err)
+	}
+	if i.Action.HTTPMethod != PostMethod {
+		t.Error("Wrong httpmethod detected", i.Action.HTTPMethod)
+	}
+	if i.SimpleTriggers[0].Type != DataType {
+		t.Error("Wrong type detected", i.SimpleTriggers[0].Type)
+	}
+
+	DeviceTriggerOK := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "device_trigger",
+			"on": "device_connected",
+			"device_id": "45336"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerOK))
+	if err != nil {
+		t.Error("This trigger should have passed ", err.Error())
+	}
+
+}

--- a/triggers/astarte_trigger_test.go
+++ b/triggers/astarte_trigger_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestMissingDataFromTriggerAction(t *testing.T) {
-
 	MissingTriggerName := `
 	{
 		"action": {
@@ -253,10 +252,8 @@ func TestInvalidTriggerData(t *testing.T) {
 	if err == nil {
 		t.Error("This trigger should have failed validation! mismatched 'on' condition for trigger type")
 	}
-
 }
 func TestInvalidTriggerInterface(t *testing.T) {
-
 	DeviceTriggerInterfaceNull := `
 	{
 		"name": "test",
@@ -346,11 +343,9 @@ func TestInvalidTriggerInterface(t *testing.T) {
 	if err != nil {
 		t.Error("This trigger should have passed!")
 	}
-
 }
 
 func TestInvalidTriggerGenericErrors(t *testing.T) {
-
 	DeviceTriggerGroupAndID := `
 	{
 		"name": "test",
@@ -392,10 +387,9 @@ func TestInvalidTriggerGenericErrors(t *testing.T) {
 	_, err = ParseTriggerFrom([]byte(DeviceTriggerNoAction))
 	if err == nil {
 		t.Error("This trigger should have Failed! required action")
-
 	}
 
-	DeviceTriggerNoTriggers := `
+	DeviceTriggerNoSimpleTriggers := `
 	{
 		"name": "test",
 		"action": {
@@ -405,12 +399,12 @@ func TestInvalidTriggerGenericErrors(t *testing.T) {
 		"simple_triggers": []
 	  }`
 
-	_, err = ParseTriggerFrom([]byte(DeviceTriggerNoTriggers))
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerNoSimpleTriggers))
 	if err == nil {
 		t.Error("This trigger should have Failed! one trigger definition is required")
 	}
 
-	DeviceTriggerTooManyTriggers := `
+	DeviceTriggerTooManySimpleTriggers := `
 	{
 		"name": "test",
 		"action": {
@@ -437,7 +431,7 @@ func TestInvalidTriggerGenericErrors(t *testing.T) {
 		]
 	  }`
 
-	_, err = ParseTriggerFrom([]byte(DeviceTriggerTooManyTriggers))
+	_, err = ParseTriggerFrom([]byte(DeviceTriggerTooManySimpleTriggers))
 	if err == nil {
 		t.Error("This trigger should have Failed! Too many triggers defined")
 	}
@@ -498,7 +492,6 @@ func TestInvalidTriggerGenericErrors(t *testing.T) {
 			"on": "device_connected",
 			"device_id": "dsagfsda",
 			"interface_name": "*"
-
 		  }
 		]
 	  }`
@@ -519,7 +512,6 @@ func TestInvalidTriggerGenericErrors(t *testing.T) {
 		  {
 			"type": "data_trigger",
 			"on": "device_disconnected"
-
 		  }
 		]
 	  }`
@@ -562,7 +554,6 @@ func TestInvalidTriggerGenericErrors(t *testing.T) {
 			"type": "data_trigger",
 			"on": "incoming_data",
 			"interface_name": "*"
-
 		  }
 		]
 	  }`
@@ -585,7 +576,6 @@ func TestInvalidTriggerGenericErrors(t *testing.T) {
 			"on": "incoming_data",
 			"interface_name": "*",
 			"match_path":"/*"
-
 		  }
 		]
 	  }`
@@ -609,7 +599,6 @@ func TestInvalidTriggerGenericErrors(t *testing.T) {
 			"interface_name": "*",
 			"match_path":"/*",
 			"value_match_operator":"=="
-
 		  }
 		]
 	  }`
@@ -618,12 +607,10 @@ func TestInvalidTriggerGenericErrors(t *testing.T) {
 	if err == nil {
 		t.Error("This trigger should have Failed!invalid data for trigger type data")
 	}
-
 }
 
 //nolint:all
 func TestParsing(t *testing.T) {
-
 	DataTriggerOk := `
 	{
 		"name": "example_trigger",
@@ -675,5 +662,4 @@ func TestParsing(t *testing.T) {
 	if err != nil {
 		t.Error("This trigger should have passed ", err.Error())
 	}
-
 }


### PR DESCRIPTION
This pr enable validation on triggers json via function "ParseTriggerFrom" and "ParseTrigger".
Check is based on official astarte documentation, resulting in the following structure schema:


```
{ 
"name" -> string, not null
"action"-> {
        "http_url" -> string nullable
        "http_method" -> enum [POST, GET, PUT, PATCH ecc] nullable
          "http_static_headers" -> json
        "ignore_ssl_errors" ->  bool default false
}
"simple_triggers array" -> one element [
                         {
                                    "type" -> enum [data_trigger,device_trigger],

                                    (only device_trigger)
                                        "on" -> device_trigger_type enum [device_connected,device_disconnected,device_error]
                                        "device_id" -> id of a device OR "*", nullable    |> mutually exclusive
                                        "group_name"-> group of devices nullable         |> mutually exclusive

                                     (only data_trigger)
                                         "on" ->data_trigger_type enum [incoming_data, value_stored, value_change, value_change_applied,  path_created, path_removed ]
                                         "interface_name"-> string not nullable (accept "*")
                                         "interface_major" ->  string(float) nullable if interface_name=="*"
                                         "match_path" ->  string nullable or "/*"
                                         "value_match_operator" -> enum [*, ==, !=, >, >=, < , <=, contains, not_contains]  (contains and not_contains can be used only with type string, binaryblob and with array types in "known_value"]
                                         "known_value" -> string nullable
}
]
}

```