### PR TITLE
Add LongIntegerArray slice processing to interface utils

### DIFF
--- a/interfaces/utils.go
+++ b/interfaces/utils.go
@@ -245,6 +245,8 @@ func processGenericSlice(mappingType AstarteMappingType, c []interface{}) error 
 			e = validateType(Integer, v)
 		case LongInteger:
 			e = validateType(LongInteger, v)
+		case LongIntegerArray:
+			e = validateType(LongInteger, v)
 		case DoubleArray:
 			e = validateType(Double, v)
 		case StringArray:


### PR DESCRIPTION
Add LongIntegerArray slice processing to interface utils

Resolves last point of https://github.com/astarte-platform/astartectl/issues/239 