### PR TITLE
Device aliases are a map, not an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.92.2] - Unreleased
+### Fixed
+- Parse device aliases as a map, not as an array.
+
 ## [0.92.1]- 2024-09-16
 ### Added
 - Add template type support for trigger, thus enabling Mustache templating.

--- a/client/appengine_data.go
+++ b/client/appengine_data.go
@@ -224,14 +224,14 @@ func (r ListDeviceInterfacesResponse) Raw(f func(*http.Response) any) any {
 }
 
 // Parses data obtained by performing a request device's aliases.
-// Returns the list of aliases as an array of strings.
+// Returns the list of aliases as a map strings to strings.
 func (r ListDeviceAliasesResponse) Parse() (any, error) {
 	defer r.res.Body.Close()
 	b, _ := io.ReadAll(r.res.Body)
-	data := gjson.GetBytes(b, "data.aliases").Array()
-	aliases := []string{}
-	for _, v := range data {
-		aliases = append(aliases, v.Str)
+	data := gjson.GetBytes(b, "data.aliases").Map()
+	aliases := map[string]string{}
+	for k, v := range data {
+		aliases[k] = v.Str
 	}
 	return aliases, nil
 }


### PR DESCRIPTION
Fix the parsing of device aliases, which are to be parsed in the same way as attributes.

See https://github.com/astarte-platform/astartectl/issues/275.