### PR TITLE
fix(triggers): remove outdated tests, add missing validation, improve code

### DIFF
--- a/triggers/astarte_trigger.go
+++ b/triggers/astarte_trigger.go
@@ -373,6 +373,11 @@ func simpleTriggerCheck(trigger *requiredAstarteSimpleTrigger) error {
 		if trigger.MatchPath == nil {
 			return errors.New("Invalid data trigger: MatchPath not set")
 		}
+		if *trigger.MatchPath == "/*" {
+			if trigger.ValueMatchOperator == nil || *trigger.ValueMatchOperator != "*" {
+				return errors.New("Invalid data trigger: if MatchPath is /*, ValueMatchOperator must be *")
+			}
+		}
 		if trigger.ValueMatchOperator == nil {
 			return errors.New("Invalid data trigger: ValueMatchOperator not set")
 		}

--- a/triggers/astarte_trigger_test.go
+++ b/triggers/astarte_trigger_test.go
@@ -353,7 +353,7 @@ func TestInvalidTriggerInterface(t *testing.T) {
 			"interface_name": "AAA",
 			"interface_major": "2",
 			"match_path":"/*",
-			"value_match_operator":"==",
+			"value_match_operator":"*",
 			"known_value":"3"
 		  }
 		]
@@ -364,7 +364,7 @@ func TestInvalidTriggerInterface(t *testing.T) {
 		t.Error("This trigger should have passed!")
 	}
 
-	DeviceTriggerMajorNullable := `
+	DataTriggerMatchPathMatchWrongA := `
 	{
 		"name": "test",
 		"action": {
@@ -383,9 +383,56 @@ func TestInvalidTriggerInterface(t *testing.T) {
 		]
 	  }`
 
-	_, err = ParseTriggerFrom([]byte(DeviceTriggerMajorNullable))
+	_, err = ParseTriggerFrom([]byte(DataTriggerMatchPathMatchWrongA))
+	if err == nil {
+		t.Error("This trigger should have failed validation! If the match_path is /*, the value_match_operator must be *")
+	}
+
+	DataTriggerMatchPathMatchWrongB := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "*",
+			"match_path":"/*",
+			"known_value":"3"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DataTriggerMatchPathMatchWrongB))
+	if err == nil {
+		t.Error("This trigger should have failed validation! If the match_path is /*, the value_match_operator cannot be missing")
+	}
+
+	DataTriggerMatchPathMatchOk := `
+	{
+		"name": "test",
+		"action": {
+			"http_url": "https://example.com/my_hook",
+			"http_method": "post"
+		},
+		"simple_triggers": [
+		  {
+			"type": "data_trigger",
+			"on": "incoming_data",
+			"interface_name": "*",
+			"match_path":"/*",
+			"value_match_operator":"*",
+			"known_value":"3"
+		  }
+		]
+	  }`
+
+	_, err = ParseTriggerFrom([]byte(DataTriggerMatchPathMatchOk))
 	if err != nil {
-		t.Error("This trigger should have passed!")
+		t.Error("This trigger should have been valid! If the match_path is /*, the value_match_operator can be *")
 	}
 
 	DeviceTriggerInterfaceMinorUpdatedNoName := `

--- a/triggers/astarte_trigger_test.go
+++ b/triggers/astarte_trigger_test.go
@@ -162,7 +162,7 @@ func TestMissingDataFromTriggerAction(t *testing.T) {
 	if err == nil {
 		t.Error("This trigger should have Failed! invalid template type")
 	}
-	DeviceTriggerEmptyTemplateType := `
+	DataTriggerEmptyTemplateType := `
 	{
 		"name": "test",
 		"action": {
@@ -179,7 +179,7 @@ func TestMissingDataFromTriggerAction(t *testing.T) {
 		]
 	  }`
 
-	_, err = ParseTriggerFrom([]byte(DeviceTriggerEmptyTemplateType))
+	_, err = ParseTriggerFrom([]byte(DataTriggerEmptyTemplateType))
 	if err == nil {
 		t.Error("This trigger should have Failed! invalid template type")
 	}
@@ -187,7 +187,7 @@ func TestMissingDataFromTriggerAction(t *testing.T) {
 }
 
 func TestInvalidTriggerData(t *testing.T) {
-	DeviceTriggerInvalidMatchOperator := `
+	DataTriggerInvalidMatchOperator := `
 	{
 		"name": "test",
 		"action": {
@@ -206,7 +206,7 @@ func TestInvalidTriggerData(t *testing.T) {
 		]
 	  }`
 
-	_, err := ParseTriggerFrom([]byte(DeviceTriggerInvalidMatchOperator))
+	_, err := ParseTriggerFrom([]byte(DataTriggerInvalidMatchOperator))
 	if err == nil {
 		t.Error("This trigger should have Failed! invalid json match operator")
 	}
@@ -286,7 +286,7 @@ func TestInvalidTriggerData(t *testing.T) {
 		},
 		"simple_triggers": [
 		  {
-			"type": "data_trigger",
+			"type": "device_trigger",
 			"on": "incoming_data"
 		  }
 		]
@@ -307,7 +307,7 @@ func TestInvalidTriggerInterface(t *testing.T) {
 		},
 		"simple_triggers": [
 		  {
-			"type": "data_trigger",
+			"type": "device_trigger",
 			"on": "incoming_data"
 		  }
 		]
@@ -318,7 +318,7 @@ func TestInvalidTriggerInterface(t *testing.T) {
 		t.Error("This trigger should have failed validation! no interfaces specified")
 	}
 
-	DeviceTriggerMajorNull := `
+	DataTriggerMajorNull := `
 	{
 		"name": "test",
 		"action": {
@@ -334,12 +334,12 @@ func TestInvalidTriggerInterface(t *testing.T) {
 		]
 	  }`
 
-	_, err = ParseTriggerFrom([]byte(DeviceTriggerMajorNull))
+	_, err = ParseTriggerFrom([]byte(DataTriggerMajorNull))
 	if err == nil {
 		t.Error("This trigger should have failed validation! no interface major specified")
 	}
 
-	DeviceTriggerMajorNotNull := `
+	DataTriggerMajorNotNull := `
 	{
 		"name": "test",
 		"action": {
@@ -359,7 +359,7 @@ func TestInvalidTriggerInterface(t *testing.T) {
 		]
 	  }`
 
-	_, err = ParseTriggerFrom([]byte(DeviceTriggerMajorNotNull))
+	_, err = ParseTriggerFrom([]byte(DataTriggerMajorNotNull))
 	if err != nil {
 		t.Error("This trigger should have passed!")
 	}


### PR DESCRIPTION
There was a missing validation on `match_path` and tests were passing with invalid triggers. In this PR the missing validation is added, the bad tests are fixed to match the validation.

Furthermore, a small refactor helps code readability and wrong test names are finally fixed according to the triggers tested.